### PR TITLE
Fix Floater.computePosition crash when arrow-locator is missing

### DIFF
--- a/lib/komps/floater.js
+++ b/lib/komps/floater.js
@@ -268,13 +268,14 @@ export default class Floater extends KompElement {
 
         if (middlewareData.arrow) {
             const {x, y} = middlewareData.arrow;
+            const arrowLocator = this.querySelector('komp-floater-arrow-locator')
             if (x != null) {
                 this.style.setProperty('--arrow-left', `${x}px`)
-                this.querySelector('komp-floater-arrow-locator').style.setProperty('left', `${x}px`)
+                if (arrowLocator) arrowLocator.style.setProperty('left', `${x}px`)
             }
             if (y != null) {
                 this.style.setProperty('--arrow-top', `${y}px`)
-                this.querySelector('komp-floater-arrow-locator').style.setProperty('top', `${x}px`)
+                if (arrowLocator) arrowLocator.style.setProperty('top', `${y}px`)
             }
         }
     }


### PR DESCRIPTION
## Summary

- Guard `this.querySelector('komp-floater-arrow-locator')` against `null` in `Floater.computePosition`. `autoUpdate` fires `updatePosition` asynchronously through a `Promise` chain, and the locator can be absent between ticks when the floater's children have been replaced (e.g. consumer reassigns `innerHTML`), producing `TypeError: Cannot read properties of null (reading 'style')`.
- Fix a typo where the locator's `top` was being set to the arrow's `x` coordinate instead of `y`, so arrows on `-left`/`-right` placements were mispositioned vertically.

Observed in production via Sentry REX-JS-272: 2,858 occurrences across 230 users, all originating from floaters that opted into `arrow: true`.

## Test plan

- [ ] Open a floater with `arrow: true`, replace its `innerHTML` while visible, trigger a reposition (resize window / scroll) — no console error, arrow stops rendering gracefully instead of crashing.
- [ ] Open a floater with `arrow: true` anchored to an element that forces `-left` or `-right` placement — arrow is vertically aligned to the anchor instead of stuck at `top: 0`.
- [ ] Existing floater consumers (Tooltip, Dropdown, etc.) continue to render arrows correctly on `-top`/`-bottom` placements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)