### PR TITLE
Add row-level readonly attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- **Row-level readonly** — `TableRow` accepts a `readonly` function (called with the record) and a new `renderCell(column, record, options)` method that resolves it per-record before delegating to `column.renderCell`. `Spreadsheet` exposes a matching `readonly` attribute and forwards it to each row, so a single `readonly: record => record.archived` declaration makes all cells in matching rows non-editable. `Table.renderRow` now accepts an optional `attrs` object that is spread into the row's construction options (#28).
+
 ### Breaking Changes
 
 - **Tooltip auto-wiring removed** — `new Tooltip({ anchor, content })` no longer attaches mouseenter/mouseleave/focus/blur/keydown listeners to the anchor. The `enable()` / `disable()` methods and the `enabled` option are removed. Use `Tooltip.delegate(container, defaults)` to install a single delegated listener that shows tooltips for any descendant with `data-tooltip` (or `title`, which is stripped to suppress the native browser tooltip). Per-element options are read from `data-tooltip-*` attributes.

--- a/docs/demo/pages/spreadsheet.html
+++ b/docs/demo/pages/spreadsheet.html
@@ -21,6 +21,7 @@ title: Spreadsheet
     const data = await response.json();
 
     document.getElementById('container').append(new Spreadsheet({
+        readonly: r => r['Name'] == 'Adolis Garcia',
         data: data,
         columns: [{
             attribute: 'Name',

--- a/lib/komps/spreadsheet.js
+++ b/lib/komps/spreadsheet.js
@@ -54,7 +54,8 @@ export default class Spreadsheet extends Table {
     static { this.define() }
 
     static assignableAttributes = {
-        scrollSnap: { type: 'boolean', default: false, null: false }
+        scrollSnap: { type: 'boolean', default: false, null: false },
+        readonly: { type: 'function', default: null, null: true }
     }
     
     static columnTypeRegistry = {
@@ -150,7 +151,11 @@ export default class Spreadsheet extends Table {
         })
         return super.connected(...args)
     }
-    
+
+    async renderRow (record, index) {
+        return super.renderRow(record, index, { readonly: this.readonly })
+    }
+
     /* -------------------
         Cell Selection
     ------------------- */

--- a/lib/komps/spreadsheet.js
+++ b/lib/komps/spreadsheet.js
@@ -7,6 +7,7 @@
  * @param {Object} [options={}]
  * @param {boolean} [options.scrollSnap=false] - Enable scroll snapping (WIP, needs to update scroll-start when frozen rows/columns stick)
  * @param {Array} [options.columns=[]] - Array of objects that initialize {@link SpreadsheetColumn Columns} that manage the rendering of {@link SpreadsheetCell Cells}
+ * @param {function} [options.readonly] - Function called with each `record` to determine whether its row should render readonly cells. Forwarded to each {@link TableRow} and resolved per-record in `row.renderCell` before delegating to `column.renderCell`. Per-cell `readonly` overrides (e.g. {@link ReadonlyColumn}, split-cell placeholders) still win.
  *
  * @example <caption>JS</caption>
  * new Spreadsheet({

--- a/lib/komps/spreadsheet/columns/checkbox-column.js
+++ b/lib/komps/spreadsheet/columns/checkbox-column.js
@@ -14,12 +14,13 @@ export default class CheckboxColumn extends Column {
         trigger(input, 'change')
     }
     
-    render (record) {
+    render (record, cell) {
         return createElement('label', {
             content: Input.create(this.type, Object.assign({
                 target: record,
                 attribute: this.attribute,
-                name: this.attribute
+                name: this.attribute,
+                disabled: cell.readonly
             }, this.inputOptions))
         })
     }

--- a/lib/komps/table.js
+++ b/lib/komps/table.js
@@ -256,17 +256,18 @@ export default class Table extends KompElement {
         return Promise.all(await (await this.data).map((record, rowIndex) => this.renderRow(record, rowIndex + 2)))
     }
     
-    async renderRow (record, index) {
+    async renderRow (record, index, attrs={}) {
         const row = new this.constructor.Row({
             record: record,
             rowIndex: index,
-            table: this
+            table: this,
+            ...attrs
         })
-        
+
         this.columns.forEach(async column => {
             row.renderColumn(column, record)
         })
-        
+
         return row
     }
     

--- a/lib/komps/table/row.js
+++ b/lib/komps/table/row.js
@@ -1,5 +1,6 @@
 import KompElement from '../element.js';
 import Group from './group.js';
+import { result } from '../../support.js';
 
 /**
  * A row in a {@link Table}, rendered as a CSS Grid subgrid.
@@ -15,7 +16,8 @@ export default class TableRow extends KompElement {
         rowIndex: { type: 'number', default: null, null: true },
         table: { type: 'object', default: null, null: true },
         height: { type: 'string', default: null, null: true },
-        record: { type: 'object', default: null, null: true }
+        record: { type: 'object', default: null, null: true },
+        readonly: { type: 'function', default: null, null: true }
     }
     
     #rowCount = 0;
@@ -48,18 +50,25 @@ export default class TableRow extends KompElement {
         }
     }
     
+    async renderCell (column, record, options={}) {
+        if (this.readonly && !options.hasOwnProperty('readonly')) {
+            options.readonly = await result(this, 'readonly', record)
+        }
+        return column.renderCell(record, options)
+    }
+
     async renderColumn (column, record) {
         if (column.splitInto) {
-            const placeholderCell = await column.renderCell(null, { readonly: true, disabled: true })
+            const placeholderCell = await this.renderCell(column, null, { readonly: true, disabled: true })
             this.append(placeholderCell)
-            
+
             let subrecords = await (typeof column.splitInto == 'function' ? column.splitInto(record) : record[column.splitInto])
             if (subrecords == undefined || subrecords.length == 0) {
                 placeholderCell.toggleAttribute('disabled', false)
                 return placeholderCell
             }
             const cells = await Promise.all(await subrecords.map(async (subrecord, i) => {
-                const cell = await column.renderCell(subrecord)
+                const cell = await this.renderCell(column, subrecord)
                 cell.groupIndex = i + 1
                 return cell
             }))
@@ -71,7 +80,7 @@ export default class TableRow extends KompElement {
                     this.generatedGroupNames.set(column.splitInto, groupName)
                 }
             }
-                
+
             let group = this.querySelector(Group.tagName + `[data-name=${groupName}]`)
             if (!group) {
                 group = new Group({
@@ -82,7 +91,7 @@ export default class TableRow extends KompElement {
             group.append(...cells)
             return cells
         } else {
-            const cell = await column.renderCell(record)
+            const cell = await this.renderCell(column, record)
             this.append(cell)
             return cell
         }


### PR DESCRIPTION
## Summary
- `TableRow` gains a `readonly` assignable attribute (function with `record` arg) and a `renderCell(column, record, options)` method that resolves it per-record and forwards the result to `column.renderCell`. `renderColumn` now routes through `renderCell`, so split-cell and standard paths both pick up the row-level readonly. Explicit `readonly` in options still wins (e.g. the placeholder cell in split rendering).
- `Spreadsheet` gains a `readonly` assignable attribute and overrides `renderRow` to forward it to each row.
- `Table.renderRow` now accepts an optional `attrs` object that is spread into the row's construction options, enabling subclasses to inject row attributes without duplicating the body.

Usage:
```js
new Spreadsheet({
    data: records,
    readonly: record => record.archived,
    columns: [...]
})
```

## Test plan
- [x] Render a Spreadsheet with `readonly: record => record.archived` and confirm cells in archived rows are non-editable
- [x] Confirm cells in non-archived rows remain editable
- [x] Confirm per-cell `readonly` overrides (e.g. `ReadonlyColumn`, split-cell placeholders) still apply regardless of row-level value
- [x] Confirm a Spreadsheet without a `readonly` attribute behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)