### PR TITLE
Memoize scanPrototypesFor to avoid per-instance prototype walks

### DIFF
--- a/lib/support.js
+++ b/lib/support.js
@@ -52,20 +52,37 @@ export function eachPrototype(obj, fn) {
 
 /**
  * Iterates over the (prototype chain)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain]
- * for a specified property in each prototype
+ * for a specified property in each prototype.
+ *
+ * Results are memoized per (object, key) pair — the inputs are typically a class
+ * constructor and a static property name (e.g. `'assignableAttributes'`), so
+ * the merged chain is stable across instances. The cache holds references to
+ * the original per-prototype values, so in-place mutations to those values
+ * (e.g. plugins calling `this.events.push(...)`) remain visible. Treat the
+ * returned array as read-only.
  *
  * @param {Object} obj - The object to climb the property chain with
  * @param {string} key - The property name to find on each prototype
  * @returns {Array} - An array consisting of the property for each prototype
  */
+const _scanPrototypesCache = new WeakMap()
 export function scanPrototypesFor(obj, key) {
-    let values = [];
+    let cache = _scanPrototypesCache.get(obj)
+    if (!cache) {
+        cache = new Map()
+        _scanPrototypesCache.set(obj, cache)
+    }
+    if (cache.has(key)) {
+        return cache.get(key)
+    }
+    const values = []
     eachPrototype(obj, p => {
         if (p.hasOwnProperty(key)) {
-            values.push(p[key]);
+            values.push(p[key])
         }
     })
-    return values;
+    cache.set(key, values)
+    return values
 }
 
 export function isInView (container, el) {


### PR DESCRIPTION
## Summary
- `scanPrototypesFor(this.constructor, key)` runs four times in `KompElement`'s constructor (`bindMethods`, `assignableAttributes`, `assignableMethods`, `events`) and twice in `TableColumn`'s — every cell, row, and column construction climbs the prototype chain and rebuilds the same arrays.
- The result depends purely on the (constructor, key) pair, so memoizing it gives every instance after the first a constant-time lookup.
- Cache is a `WeakMap` keyed by the constructor → `Map` keyed by property name → result array. The cache stores references to the per-prototype values (not copies), so plugin in-place mutations like `this.events.push('columnResize', 'rowResize')` in `resizable.js` remain visible whether they run before or after first scan.

## Why this is safe
All current call sites use the pattern `scanPrototypesFor(...).filter(x => x).reverse().forEach(...)`. `filter` returns a fresh array, and the subsequent `reverse` mutates that fresh array — the cached array is never touched. The doc comment notes that callers should treat the returned array as read-only.

## Performance impact
Hottest path: building 1000×10 = 10,000 cells previously did 40,000 prototype walks (4 per cell). After this change it's 4 per Cell *class* total, then O(1) lookups thereafter.

## Test plan
- [ ] Render a table/spreadsheet, confirm cells/rows/columns construct identically (attributes, events, methods all wired up).
- [ ] Confirm `Spreadsheet.events` includes plugin-added entries (`columnResize`, `rowResize`, etc.) and that `onColumnResize` constructor option still binds.
- [ ] Smoke-test docs build (`npm run docs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)