### PR TITLE
Chunk initial row render so large tables paint immediately

### DIFF
--- a/lib/komps/table.js
+++ b/lib/komps/table.js
@@ -7,6 +7,7 @@
  * @param {Object} [options={}]
  * @param {Array} [options.data=[]] - Each record of the array generates a row by passing the record to each render method of the defined columns. Uses `forEach` on object, so can use with any Enumerable-ish object.
  * @param {Array} [options.columns=[]] - Array of objects that initialize {@link TableColumn Columns} that manage the rendering of {@link TableCell Cells}
+ * @param {number} [options.chunkSize=50] - Number of rows rendered synchronously on first paint. Remaining rows stream in via `requestIdleCallback` so the table appears immediately on large datasets. Set to `0` to render every row up front (legacy behavior).
  *
  * @fires Table#rendered
  *
@@ -46,7 +47,8 @@ export default class Table extends KompElement {
     
     static assignableAttributes = {
         data: { type: 'array', default: [], null: false },
-        columns: { type: 'array', default: [], null: false }
+        columns: { type: 'array', default: [], null: false },
+        chunkSize: { type: 'number', default: 50, null: false }
     }
     
     static tagName = 'komp-table'
@@ -97,13 +99,17 @@ export default class Table extends KompElement {
                 for (const m of mutations) {
                     for (const node of m.addedNodes) {
                         if (node.nodeType === 1 && node.matches?.(this.rowSelector)) {
-                            node.table.setTemplateRows()
+                            if (!node.table._chunkRenderInProgress) {
+                                node.table.setTemplateRows()
+                            }
                             return
                         }
                     }
                     for (const node of m.removedNodes) {
                         if (node.nodeType === 1 && node.matches?.(this.rowSelector)) {
-                            node.table.setTemplateRows()
+                            if (!node.table._chunkRenderInProgress) {
+                                node.table.setTemplateRows()
+                            }
                             return
                         }
                     }
@@ -202,14 +208,60 @@ export default class Table extends KompElement {
     }
     
     async render () {
+        const data = Array.from((await this.data) || [])
+        const total = data.length
+        const initialCount = this.chunkSize > 0 ? Math.min(this.chunkSize, total) : total
+
+        const initialRows = await Promise.all(
+            data.slice(0, initialCount).map((record, i) => this.renderRow(record, i + 2))
+        )
+
         const frag = document.createDocumentFragment()
         content(frag, [
             this.renderHeader(),
-            this.renderRows()
+            initialRows
         ])
         this.replaceChildren(frag)
         this.renderFrozenDivider()
+
+        if (initialCount < total) {
+            this._chunkRenderInProgress = true
+            try {
+                await this._renderRemainingChunks(data, initialCount)
+            } finally {
+                this._chunkRenderInProgress = false
+            }
+            this.setTemplateRows()
+        }
+
         this.trigger('rendered')
+    }
+
+    async _renderRemainingChunks (data, offset) {
+        const total = data.length
+        const chunkSize = Math.max(this.chunkSize, 1)
+
+        while (offset < total) {
+            await this._idle()
+            const end = Math.min(offset + chunkSize, total)
+            const rows = await Promise.all(
+                data.slice(offset, end).map((record, i) => this.renderRow(record, offset + i + 2))
+            )
+            const frag = document.createDocumentFragment()
+            rows.forEach(row => frag.appendChild(row))
+            this.appendChild(frag)
+            offset = end
+        }
+    }
+
+    _idle () {
+        return new Promise(resolve => {
+            if (typeof requestIdleCallback === 'function') {
+                requestIdleCallback(() => resolve(), { timeout: 100 })
+            } else {
+                setTimeout(resolve, 0)
+            }
+        })
     }
     
     renderFrozenDivider () {


### PR DESCRIPTION
## Summary
Implements recommendation #4 from the spreadsheet performance review — **lazy initial render** with chunked, idle-time streaming of subsequent rows. Targets `main` as a 2.0 feature.

The first paint of a 1,000-row spreadsheet previously waited on construction of ~10K cell custom elements (constructors, `connectedCallback`s, listeners, `column.cells.add`, etc.). With this change, the first 50 rows mount synchronously and the rest stream in via `requestIdleCallback` so the browser gets a chance to paint, accept input, and run other work between batches.

## Design

- **New attribute**: `chunkSize` (default `50`). `chunkSize=0` disables chunking and restores the previous "render everything up front" behavior.
- **Initial chunk**: built synchronously, mounted via `replaceChildren(frag)` exactly like before.
- **Remaining chunks**: each batch awaits `requestIdleCallback` (`setTimeout(0)` fallback for Safari < 16 / SSR), constructs a `DocumentFragment`, and appends. A `requestIdleCallback` `timeout: 100` ensures forward progress on busy main threads.
- **`setTemplateRows()` suppression**: a `_chunkRenderInProgress` flag tells the row mutation observer to skip its per-batch `setTemplateRows()` rebuild while chunks are streaming. `setTemplateRows()` is called once when streaming completes. Without this, each chunk insertion would do an O(rows-so-far) `querySelectorAll` — total cost O(N²/chunkSize).
- **`this.rendering` promise semantics unchanged**: it still resolves only when *every* row has rendered. Code paths like `appendRow`/`removeRow` that chain on `this.rendering` continue to wait for full render. Only first paint moves earlier.

## Why not full virtualization
Discussed in the review: with CSS subgrid as the layout mechanism, removing rows on scroll loses subgrid alignment and breaks `slice()`/`at()`/`outlineCells()` which all walk DOM cells. Virtualization is the right fix for *steady-state* scroll/edit slowness; this PR is the right fix for *initial paint* slowness, and is a much smaller change.

## Breaking change consideration
The new default (`chunkSize: 50`) means `await this.rendering` settles slightly later for tables with > 50 rows (one or more idle callbacks worth of delay vs synchronous). Consumers that depended on synchronous behavior — `new Table(...)` then immediately reading `.rows` — were already broken because the original render was async too. Setting `chunkSize: 0` restores the exact previous timing.

## Test plan
- [x] Render a 1,000-row spreadsheet with default `chunkSize`. Confirm first paint shows ~50 rows immediately and remaining rows stream in within ~1s without jank.
- [x] Render with `chunkSize: 0`. Confirm behavior matches pre-change (single mount, no streaming).
- [x] Render with `data.length < chunkSize`. Confirm everything mounts in the initial batch and `_renderRemainingChunks` is not entered.
- [x] Render with empty `data`. Confirm header renders and `rendered` event fires.
- [x] During streaming, click a cell in the initial chunk — confirm interactions work before all chunks finish (delegated listeners on Spreadsheet).
- [x] Call `appendRow`/`removeRow` while streaming. Confirm the operation chains correctly via `this.rendering` and resulting row order is correct.
- [x] Resize a column during streaming. Confirm no layout corruption (initial chunk has correct widths; later chunks pick up the resized template).
- [x] Verify `setTemplateRows()` is called exactly once at the end of streaming (set a breakpoint or temporary log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)