### PR TITLE
fix KompElement.include dedupe colliding on default-export plugins

### DIFF
--- a/lib/komps/element.js
+++ b/lib/komps/element.js
@@ -139,9 +139,9 @@ export default class KompElement extends HTMLElement {
     static get observedAttributes() { return this.watch }
     
     static include(module) {
-        if (!this._plugins) { this._plugins = [] }
-        if (!this._plugins.includes(module.name)) {
-            this._plugins.push(module.name)
+        if (!Object.hasOwn(this, '_plugins')) { this._plugins = new Set() }
+        if (!this._plugins.has(module)) {
+            this._plugins.add(module)
             module.call(this, this.prototype)
         }
     }


### PR DESCRIPTION
Backport of #34 to 1.x.

## Summary

`KompElement.include()` deduped plugins by `module.name`, but per the ES module spec an anonymously default-exported function has `.name === "default"`. Every plugin in `lib/komps/table/plugins/*` uses `export default function (proto)`, so they all collide on `"default"` and the second `include()` onward is silently skipped — including the nested `this.include(cellsDimensions)` inside `resizable` and `reorderable`.

Symptom: include any two plugins on a Spreadsheet (e.g. `resizable` + `reorderable`) and `cellsDimensions` is never installed. First column resize throws `this.cellsDimensions is not a function` at `resizable.js:181`.

## Fix

- Dedupe by module reference (the function itself) using a `Set` instead of the function's `.name`.
- Use `Object.hasOwn` to initialize `_plugins` so subclasses don't share the parent's set via the prototype chain.

## Test plan

- [ ] On a fresh `Spreadsheet`, call `Spreadsheet.include(resizable); Spreadsheet.include(reorderable); Spreadsheet.include(collapsible);` and confirm a column resize works without throwing
- [ ] Reload existing demos that already include plugins and confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)