### PR TITLE
add Masonry component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Components
 
-- **Masonry** — Pattern-driven grid layout with optional drag-resize and drag-reorder. `cellPattern` (e.g. `"3 3 6, 6 6, 7 5, 12"`) declares per-row cell column counts; `rowPattern` declares row track heights (e.g. `"200px 100px auto"`); both repeat to cover all children. `gridCount` defaults to the LCM of `cellPattern` row sums. With `resizable`, drag handles snap to integer grid columns and pixel row heights. With `reorderable`, dropping a cell into a row redistributes that row evenly across the grid; the source row likewise redistributes.
+- **Masonry** — Pattern-driven grid layout with optional drag-resize and drag-reorder. `cellPattern` (e.g. `"3 3 6, 6 6, 7 5, 12"`) declares per-row cell column counts; `rowPattern` declares row track heights (e.g. `"200px 100px auto"`); both repeat to cover all children. `columnCount` defaults to the LCM of `cellPattern` row sums. With `resizable`, drag handles snap to integer grid columns and pixel row heights. With `reorderable`, dropping a cell into a row redistributes that row evenly across the grid; the source row likewise redistributes.
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Components
+
+- **Masonry** — Pattern-driven grid layout with optional drag-resize and drag-reorder. `cellPattern` (e.g. `"3 3 6, 6 6, 7 5, 12"`) declares per-row cell column counts; `rowPattern` declares row track heights (e.g. `"200px 100px auto"`); both repeat to cover all children. `gridCount` defaults to the LCM of `cellPattern` row sums. With `resizable`, drag handles snap to integer grid columns and pixel row heights. With `reorderable`, dropping a cell into a row redistributes that row evenly across the grid; the source row likewise redistributes.
+
 ### New Features
 
 - **Row-level readonly** — `TableRow` accepts a `readonly` function (called with the record) and a new `renderCell(column, record, options)` method that resolves it per-record before delegating to `column.renderCell`. `Spreadsheet` exposes a matching `readonly` attribute and forwards it to each row, so a single `readonly: record => record.archived` declaration makes all cells in matching rows non-editable. `Table.renderRow` now accepts an optional `attrs` object that is spread into the row's construction options (#28).

--- a/docs/demo/pages/masonry.html
+++ b/docs/demo/pages/masonry.html
@@ -1,0 +1,53 @@
+<!--
+title: Masonry
+-->
+<style>
+    .demo-container {
+        position: relative;
+        border: 1px solid #e2e2ea;
+        border-radius: 0.5em;
+        background: white;
+        padding: 1em;
+    }
+    komp-masonry {
+        gap: 8px;
+        block-size: 600px;
+    }
+    komp-masonry > .cell {
+        background: #ede8f5;
+        border-radius: 0.25em;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.25em;
+        color: #5e5ce6;
+        user-select: none;
+    }
+    .hint {
+        text-align: center;
+        padding: 0.5em;
+        font-size: 0.85em;
+        color: #888;
+    }
+</style>
+
+<p class="hint">Drag cell edges or row dividers to resize. Drag a cell to a new row to redistribute.</p>
+<div class="demo-container">
+    <komp-masonry id="m"
+        cellPattern="3 3 6, 6 6, 7 5, 12"
+        rowPattern="1fr 1fr 0.5fr 1fr"
+        resizable
+        reorderable>
+    </komp-masonry>
+</div>
+
+<script type="module">
+    import Masonry from './lib/komps/masonry.js';
+    import { createElement } from 'dolla';
+
+    const m = document.getElementById('m');
+    for (let i = 1; i <= 8; i++) {
+        m.append(createElement('div', { class: 'cell', content: String(i) }));
+    }
+    m.render();
+</script>

--- a/docs/demo/pages/masonry.html
+++ b/docs/demo/pages/masonry.html
@@ -49,5 +49,4 @@ title: Masonry
     for (let i = 1; i <= 8; i++) {
         m.append(createElement('div', { class: 'cell', content: String(i) }));
     }
-    m.render();
 </script>

--- a/docs/images/icons/masonry.svg
+++ b/docs/images/icons/masonry.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+<rect x="3" y="3" width="11" height="7"/><rect x="17" y="3" width="13" height="7"/>
+<rect x="3" y="13" width="17" height="7"/><rect x="23" y="13" width="7" height="7"/>
+<rect x="3" y="23" width="8" height="7"/><rect x="14" y="23" width="16" height="7"/>
+</svg>

--- a/lib/komps.js
+++ b/lib/komps.js
@@ -3,6 +3,7 @@ export { default as Modal } from './komps/modal.js';
 export { default as Floater } from './komps/floater.js';
 export { default as Table } from './komps/table.js';
 export { default as Input } from './komps/input.js';
+export { default as Masonry } from './komps/masonry.js';
 export { default as Tooltip } from './komps/tooltip.js';
 export { default as Dropdown } from './komps/dropdown.js';
 export { default as NotificationCenter } from './komps/notification-center.js';

--- a/lib/komps/masonry.js
+++ b/lib/komps/masonry.js
@@ -1,8 +1,5 @@
 /**
- * A managed CSS-Grid masonry layout. Each direct child becomes a cell placed via spans
- * derived from `cellPattern`. Pattern values are integer column counts (not fr units),
- * separated by spaces with commas separating rows. The pattern repeats to cover all
- * children. `rowPattern` lists row track heights and similarly repeats.
+ * A managed and customizable CSS-Grid masonry-style layout. Each direct child becomes a cell placed via `cellPattern`.
  *
  * @class Masonry
  * @extends KompElement
@@ -10,12 +7,12 @@
  * @param {Object} [options={}]
  * @param {string} [options.cellPattern="1"] - Per-row cell column counts. Rows separated by `,`. Example: `"3 3 6, 6 6, 7 5, 12"`
  * @param {string} [options.rowPattern="auto"] - Repeating row heights (any CSS row track value). Example: `"200px 100px auto"`
- * @param {number} [options.gridCount] - Number of grid columns. Defaults to LCM of `cellPattern` row sums.
+ * @param {number} [options.columnCount] - Number of grid columns. Defaults to least common multiple of `cellPattern` row sums.
  * @param {boolean} [options.resizable=false] - When true, render drag handles between cells (horizontal) and between rows (vertical) for live resizing
- * @param {boolean} [options.reorderable=false] - When true, dragging a cell moves it to a new row; the source and destination rows redistribute their cells evenly across `gridCount`
+ * @param {boolean} [options.reorderable=false] - When true, dragging a cell moves it to a new row; the source and destination rows redistribute their cells evenly across `columnCount`
+ * @param {string} [options.handleSelector] - CSS selector for an in-cell drag handle. When set, only `pointerdown` on a matching descendant starts the reorder; otherwise the whole cell is grabbable. Has no effect when `reorderable` is false.
  * @param {string|HTMLElement|Array|Object} [options.content] - Initial children. Each becomes a cell.
  *
- * @fires Masonry#rendered
  * @fires Masonry#resize
  * @fires Masonry#reorder
  *
@@ -40,11 +37,6 @@
  */
 
 /**
- * Fired after layout is computed and cells are placed
- * @event Masonry#rendered
- */
-
-/**
  * Fired after a resize via handle. `event.detail` includes `{ axis, rowIndex, cellIndex, span, neighborSpan }` for column resize, or `{ axis, rowIndex, height }` for row resize.
  * @event Masonry#resize
  */
@@ -54,7 +46,8 @@
  * @event Masonry#reorder
  */
 
-import { content as setContent, createElement } from 'dolla';
+import { createElement, innerHeight, insertAfter, insertBefore } from 'dolla';
+import { groupBy } from '../support.js';
 import KompElement from './element.js';
 
 function gcd (a, b) { return b === 0 ? a : gcd(b, a % b) }
@@ -62,41 +55,96 @@ function lcm (a, b) { return (a * b) / gcd(a, b) }
 
 export default class Masonry extends KompElement {
     static tagName = 'komp-masonry'
-    static { this.define() }
 
     static assignableAttributes = {
         cellPattern: { type: 'string', default: '1', null: false },
         rowPattern: { type: 'string', default: 'auto', null: false },
-        gridCount: { type: 'number', default: null, null: true },
+        columnCount: { type: 'number', default: null, null: true },
         resizable: { type: 'boolean', default: false, null: false },
-        reorderable: { type: 'boolean', default: false, null: false }
+        reorderable: { type: 'boolean', default: false, null: false },
+        handleSelector: { type: 'string', default: null, null: true }
     }
 
-    static watch = ['cellPattern', 'rowPattern', 'gridCount', 'resizable', 'reorderable']
-    static events = ['rendered', 'resize', 'reorder']
-    static bindMethods = ['_onPointerDown']
-
-    constructor (attrs = {}) {
-        const initialContent = attrs.content
-        delete attrs.content
-        super(attrs)
-        this._initialContent = initialContent
-    }
+    static watch = ['cellPattern', 'rowPattern', 'columnCount', 'resizable', 'reorderable']
+    static events = ['resize', 'reorder']
+    static bindMethods = ['_onPointerDown', '_onMutation']
 
     initialize () {
         super.initialize()
-        if (this._initialContent != null) {
-            setContent(this, this._initialContent)
-            this._initialContent = null
-        }
-        this.render()
+        this._mutationObserver = new MutationObserver(this._onMutation)
         this.addEventListener('pointerdown', this._onPointerDown)
+        
+        // Publish current gap sizes as CSS vars so handles can offset their
+        // indicators to land in the gap center without per-handle JS math.
+        // NOTE: this may get out of sync if style changes
+        const computed = getComputedStyle(this)
+        const shorthand = (computed.gap || '').split(/\s+/).filter(Boolean)
+        const rowGap = computed.rowGap || shorthand[0] || '0px'
+        const colGap = computed.columnGap || shorthand[1] || shorthand[0] || '0px'
+        this.style.setProperty('--komp-masonry-column-gap', colGap)
+        this.style.setProperty('--komp-masonry-row-gap', rowGap)
+    }
+
+    connected () {
+        this._mutationObserver?.observe(this, { childList: true })
+        this.cellPatternChanged()
+    }
+
+    disconnected () {
+        this._mutationObserver?.disconnect()
+    }
+
+    /**
+     * MutationObserver callback. Reapplies the pattern when direct children
+     * are added or removed externally. Ignores:
+     *   - internal handle / drop-indicator elements that the component manages itself
+     *   - cells that appear in both addedNodes and removedNodes (i.e. moved within the masonry, as during a reorder)
+     */
+    _onMutation (mutations) {
+        const added = new Set()
+        const removed = new Set()
+        function isLocal (n) {
+            return n.localName === 'komp-masonry-handle' ||
+                n.localName === 'komp-masonry-drop-indicator' ||
+                n.classList.contains('komp-masonry-drag-clone')
+        }
+        for (const m of mutations) {
+            for (const node of m.addedNodes) {
+                if (node.nodeType === 1 && !isLocal(node)) {
+                    added.add(node)
+                    if (this.resizable) {
+                        if (!node.handle) {
+                            node.handle = createElement('komp-masonry-handle', {
+                                class: 'vertical'
+                            })
+                            node.handle.cell = node
+                        }
+                        insertAfter(node, node.handle)
+                    }
+                }
+            }
+            for (const node of m.removedNodes) {
+                if (node.nodeType === 1 && !isLocal(node)) {
+                    removed.add(node)
+                    if (this.resizable) {
+                        if (node.handle) {
+                            node.handle.remove()
+                            delete node.handle.cell
+                            delete node.handle
+                        }
+                    }
+                }
+            }
+        }
+        if (added.size || removed.size) {
+            this.cellPatternChanged()
+        }
     }
 
     changed (attribute) {
         if (this._suppressRender) return
-        if (this.is_initialized && this.constructor.watch.includes(attribute)) {
-            this.render()
+        if (this.is_initialized && attribute != 'cellPattern' && this.constructor.watch.includes(attribute)) {
+            this.cellPatternChanged()
         }
     }
 
@@ -105,147 +153,99 @@ export default class Masonry extends KompElement {
      * @returns {HTMLElement[]}
      */
     get cells () {
-        return Array.from(this.children).filter(c => c.localName !== 'komp-masonry-handle')
+        return this.querySelectorAll('& > *:not(komp-masonry-handle):not(.komp-masonry-drag-clone)')
+    }
+    
+    get handles () {
+        return this.querySelectorAll('& > komp-masonry-handle')
+    }
+    
+    rowPatternChanged(was, now) {
+        if (was == now) return;
+        
+        this.style.gridAutoRows = now
     }
 
     /**
-     * Replace cell content and re-render
-     * @param {*} value - dolla-shaped content
+     * Walk `cellPattern` to assign each direct child a CSS grid area,
+     * compute `columnCount` (LCM of row sums when not explicit), and set the
+     * parent grid template. Called automatically on `cellPattern` change
+     * and on child mutation.
      */
-    setContent (value) {
-        this._removeHandles()
-        setContent(this, value)
-        this.render()
-    }
+    cellPatternChanged (was, now) {
+        if (this.supressPatternPaint) return;
+        now = now || this.cellPattern
+        if (was != null && was === now) return;
+        const matrix = this._cellPatternToMatrix(now)
+        if (matrix.length === 0) return
 
-    parsePattern () {
-        return this.cellPattern.split(',').map(row =>
+        this._columnCount = this.columnCount
+            || matrix.map(r => r.reduce((a, b) => a + b, 0)).reduce((a, b) => lcm(a, b), 1)
+        this.style.gridTemplateColumns = `repeat(${this._columnCount}, 1fr)`
+
+        // matrixRow cycles through `matrix` (0-indexed); cssRow / cssCol are
+        // CSS grid lines (1-indexed) and cssRow keeps counting up beyond the
+        // pattern length.
+        let matrixRow = 0
+        let cellInRow = 0
+        let cssRow = 1
+        let cssCol = 1
+
+        this.cells.forEach(cell => {
+            const span = matrix[matrixRow][cellInRow]
+            cell.style.gridArea = `${cssRow} / ${cssCol} / span 1 / span ${span}`
+            cell.dataset.rowIndex = cssRow - 1
+            cell.dataset.colIndex = cssCol - 1
+            cell.dataset.cellIndex = cellInRow
+
+            if (this.resizable) {
+                if (cell.handle) {
+                    // Handle sits at the column line *after* the cell.
+                    cell.handle.style.gridArea = `${cssRow} / ${cssCol + span} / span 1 / span 1`
+                    cell.handle.dataset.rowIndex = cssRow - 1
+                    cell.handle.dataset.cellIndex = cellInRow
+                    // Last cell in a row has no right-edge boundary to resize.
+                    cell.handle.toggleAttribute('hidden', cellInRow === matrix[matrixRow].length - 1)
+                }
+            }
+
+            cssCol += span
+            cellInRow++
+            if (cellInRow >= matrix[matrixRow].length) {
+                matrixRow = (matrixRow + 1) % matrix.length
+                cellInRow = 0
+                cssRow++
+                cssCol = 1
+            }
+        })
+        
+        if (this.resizable) {
+            this.querySelectorAll(`komp-masonry-handle.horizontal`).forEach(el => el.remove())                                                                                                                         
+            for (let i = cssRow - 2; i > 0; i--) {                                                                                                                       
+                if (!this.querySelector(`komp-masonry-handle.horizontal[data-row-index="${i - 1}"]`)) {                                                                      
+                    this.append(createElement('komp-masonry-handle', {                                                                                                   
+                        class: 'horizontal',                                                                                                                           
+                        data: {rowIndex: i - 1},
+                        style: {
+                            'grid-area': `${i} / 1 / span 1 / -1`
+                        }                                                                                                                      
+                    }))                                                                                                                                                  
+                }                                                                                                                                                        
+            }                                                                                                                                                            
+        } 
+    }
+    
+    _cellPatternToMatrix (pattern) {
+        return (pattern || this.cellPattern).split(',').map(row =>
             row.trim().split(/\s+/).map(v => parseInt(v, 10)).filter(n => !isNaN(n) && n > 0)
         ).filter(row => row.length > 0)
-    }
-
-    parseRowPattern () {
-        return this.rowPattern.split(/\s+/).map(s => s.trim()).filter(Boolean)
-    }
-
-    /**
-     * Computed grid column count. Honors explicit `gridCount` or derives from
-     * the LCM of `cellPattern` row sums.
-     */
-    get computedGridCount () {
-        if (this.gridCount) return this.gridCount
-        const sums = this.parsePattern().map(row => row.reduce((a, b) => a + b, 0))
-        if (sums.length === 0) return 1
-        return sums.reduce((a, b) => lcm(a, b))
-    }
-
-    render () {
-        const cells = this.cells
-        const pattern = this.parsePattern()
-        const explicitGrid = this.gridCount
-        const baseGrid = explicitGrid || pattern.map(r => r.reduce((a, b) => a + b, 0)).reduce((a, b) => lcm(a, b), 1)
-        const gridCount = baseGrid
-
-        this._removeHandles()
-
-        if (pattern.length === 0 || cells.length === 0) {
-            this.style.display = 'grid'
-            this.style.gridTemplateColumns = `repeat(${gridCount}, 1fr)`
-            this.style.gridTemplateRows = ''
-            this.trigger('rendered')
-            return
-        }
-
-        // Walk pattern to assign each cell a row + span
-        const rows = []
-        let currentRow = null
-        let patternRowIdx = 0
-        let patternCellIdx = 0
-
-        const newRow = () => {
-            currentRow = { spans: [], cells: [] }
-            rows.push(currentRow)
-        }
-        newRow()
-
-        for (let i = 0; i < cells.length; i++) {
-            const cell = cells[i]
-            const span = pattern[patternRowIdx][patternCellIdx]
-            currentRow.spans.push(span)
-            currentRow.cells.push(cell)
-
-            patternCellIdx++
-            if (patternCellIdx >= pattern[patternRowIdx].length) {
-                patternRowIdx = (patternRowIdx + 1) % pattern.length
-                patternCellIdx = 0
-                if (i < cells.length - 1) newRow()
-            }
-        }
-
-        // Apply explicit grid placement
-        rows.forEach((row, rIdx) => {
-            let col = 1
-            row.cells.forEach((cell, cIdx) => {
-                const span = row.spans[cIdx]
-                cell.style.gridColumn = `${col} / span ${span}`
-                cell.style.gridRow = String(rIdx + 1)
-                col += span
-            })
-        })
-
-        // Set parent grid templates
-        const rp = this.parseRowPattern()
-        const expandedRows = Array.from({ length: rows.length }, (_, i) => rp[i % rp.length] || 'auto').join(' ')
-        this.style.display = 'grid'
-        this.style.gridTemplateColumns = `repeat(${gridCount}, 1fr)`
-        this.style.gridTemplateRows = expandedRows
-
-        this._rows = rows
-        this._gridCount = gridCount
-
-        if (this.resizable) this._renderHandles()
-
-        this.trigger('rendered')
-    }
+    } 
+    _cellMatrixToPattern (matrix) {
+        return matrix.map(x => x.join(" ")).join(",")
+    } 
 
     _removeHandles () {
-        Array.from(this.querySelectorAll(':scope > komp-masonry-handle')).forEach(h => h.remove())
-    }
-
-    _renderHandles () {
-        const rows = this._rows
-        const gridCount = this._gridCount
-
-        rows.forEach((row, rIdx) => {
-            // Vertical handle between adjacent cells in a row (column resize)
-            let col = 1
-            row.cells.forEach((cell, cIdx) => {
-                col += row.spans[cIdx]
-                if (cIdx < row.cells.length - 1) {
-                    const handle = createElement('komp-masonry-handle', {
-                        class: 'vertical',
-                        data: { rowIndex: rIdx, cellIndex: cIdx },
-                        style: {
-                            gridColumn: String(col),
-                            gridRow: String(rIdx + 1)
-                        }
-                    })
-                    this.append(handle)
-                }
-            })
-            // Horizontal handle on the bottom edge (row resize), skip last row
-            if (rIdx < rows.length - 1) {
-                const handle = createElement('komp-masonry-handle', {
-                    class: 'horizontal',
-                    data: { rowIndex: rIdx },
-                    style: {
-                        gridColumn: `1 / ${gridCount + 1}`,
-                        gridRow: String(rIdx + 1)
-                    }
-                })
-                this.append(handle)
-            }
-        })
+        this.querySelectorAll(':scope > komp-masonry-handle').forEach(h => h.remove())
     }
 
     _onPointerDown (e) {
@@ -255,20 +255,13 @@ export default class Masonry extends KompElement {
             return
         }
         if (this.reorderable) {
-            const cell = this.cells.find(c => c === e.target || c.contains(e.target))
+            if (this.handleSelector) {
+                const grip = e.target.closest(this.handleSelector)
+                if (!grip || !this.contains(grip)) return
+            }
+            const cell = e.target.closest(`${this.localName} > *`)
             if (cell) this._startReorder(e, cell)
         }
-    }
-
-    _columnPx () {
-        const rect = this.getBoundingClientRect()
-        const style = getComputedStyle(this)
-        const padL = parseFloat(style.paddingLeft) || 0
-        const padR = parseFloat(style.paddingRight) || 0
-        const gap = parseFloat(style.columnGap) || 0
-        const usable = rect.width - padL - padR
-        const totalGap = gap * (this._gridCount - 1)
-        return (usable - totalGap) / this._gridCount
     }
 
     _startResize (e, handle) {
@@ -282,90 +275,94 @@ export default class Masonry extends KompElement {
         const startY = e.clientY
 
         if (isVertical) {
+            const colPx = this._columnPx
+            const patternMatrix = this._cellPatternToMatrix()
             const cellIndex = parseInt(handle.dataset.cellIndex, 10)
-            const row = this._rows[rowIndex]
-            const cell = row.cells[cellIndex]
-            const startSpan = row.spans[cellIndex]
-            const startNeighborSpan = row.spans[cellIndex + 1]
-            const colPx = this._columnPx()
+            const rowPattern = patternMatrix[rowIndex]
+            const cell = handle.cell
+            const startSpan = rowPattern[cellIndex]
+            const startNeighborSpan = rowPattern[cellIndex + 1]
             const totalSpan = startSpan + startNeighborSpan
 
             const move = (ev) => {
                 const delta = Math.round((ev.clientX - startX) / colPx)
                 let newSpan = Math.min(Math.max(1, startSpan + delta), totalSpan - 1)
                 let newNeighborSpan = totalSpan - newSpan
-                row.spans[cellIndex] = newSpan
-                row.spans[cellIndex + 1] = newNeighborSpan
-                this._applyRowSpans(rowIndex)
-                this._repositionRowHandles(rowIndex)
+                rowPattern[cellIndex] = newSpan
+                rowPattern[cellIndex + 1] = newNeighborSpan
+                this.cellPattern = this._cellMatrixToPattern(patternMatrix)
             }
             const up = (ev) => {
                 window.removeEventListener('pointermove', move)
                 handle.classList.remove('active')
                 this.releasePointerCapture(e.pointerId)
-                this._persistRowsToPattern()
+                this.cellPattern = patternMatrix.map(r => r.join(" ")).join(", ")
                 this.trigger('resize', { detail: {
                     axis: 'column',
+                    cellPattern: this.cellPattern,
                     rowIndex,
                     cellIndex,
-                    span: row.spans[cellIndex],
-                    neighborSpan: row.spans[cellIndex + 1]
+                    span: rowPattern[cellIndex],
+                    neighborSpan: rowPattern[cellIndex + 1]
                 }})
             }
             window.addEventListener('pointermove', move)
             window.addEventListener('pointerup', up, { once: true })
         } else {
-            // Row height resize. Convert auto/derived height to pixels and grow/shrink.
-            const rp = this.parseRowPattern()
-            const tracks = this.style.gridTemplateRows.split(/\s+/)
-            const startHeight = this._measureRowHeight(rowIndex)
-            const move = (ev) => {
-                const newHeight = Math.max(10, startHeight + (ev.clientY - startY))
-                tracks[rowIndex] = newHeight + 'px'
-                this.style.gridTemplateRows = tracks.join(' ')
+            // Row resize: redistribute the combined height of the row above
+            // and the row below the handle. Other rows stay fixed. The
+            // cyclic rowPattern is expanded to one entry per CSS row so the
+            // change doesn't bleed into other rows that share its slot.
+            const rowCount = Math.max(0, ...Array.from(this.cells, c => parseInt(c.dataset.rowIndex, 10))) + 1
+            const rp = (this.rowPattern || '').split(/\s+/).filter(Boolean)
+            const tracks = Array.from({ length: rowCount }, (_, i) => rp[i % rp.length] || 'auto')
+
+            // Group cells by row so we can measure both rows' rendered heights
+            const cellsByRow = []
+            for (const c of this.cells) {
+                const r = parseInt(c.dataset.rowIndex, 10)
+                ;(cellsByRow[r] = cellsByRow[r] || []).push(c)
             }
-            const up = (ev) => {
+            const heightOf = cells => Math.max(0, ...cells.map(c => c.offsetHeight))
+            const startAbove = heightOf(cellsByRow[rowIndex] || [])
+            const startBelow = heightOf(cellsByRow[rowIndex + 1] || [])
+            const totalHeight = startAbove + startBelow
+            const containerHeight = innerHeight(this) || 1
+
+            const move = (ev) => {
+                const dy = ev.clientY - startY
+                const newAbove = Math.max(10, Math.min(totalHeight - 10, startAbove + dy))
+                const newBelow = totalHeight - newAbove
+                tracks[rowIndex]     = ((newAbove / containerHeight) * 100).toFixed(2) + '%'
+                tracks[rowIndex + 1] = ((newBelow / containerHeight) * 100).toFixed(2) + '%'
+                this.rowPattern = tracks.join(' ')
+            }
+            const up = () => {
                 window.removeEventListener('pointermove', move)
                 handle.classList.remove('active')
                 this.releasePointerCapture(e.pointerId)
                 this.trigger('resize', { detail: {
                     axis: 'row',
+                    rowPattern: this.rowPattern,
                     rowIndex,
-                    height: parseFloat(tracks[rowIndex])
+                    aboveHeight: tracks[rowIndex],
+                    belowHeight: tracks[rowIndex + 1]
                 }})
             }
             window.addEventListener('pointermove', move)
             window.addEventListener('pointerup', up, { once: true })
         }
     }
-
-    _measureRowHeight (rowIndex) {
-        const row = this._rows[rowIndex]
-        if (!row || row.cells.length === 0) return 0
-        return Math.max(...row.cells.map(c => c.offsetHeight))
-    }
-
-    _applyRowSpans (rowIndex) {
-        const row = this._rows[rowIndex]
-        let col = 1
-        row.cells.forEach((cell, cIdx) => {
-            const span = row.spans[cIdx]
-            cell.style.gridColumn = `${col} / span ${span}`
-            col += span
-        })
-    }
-
-    _repositionRowHandles (rowIndex) {
-        const row = this._rows[rowIndex]
-        const handles = Array.from(this.querySelectorAll(`:scope > komp-masonry-handle.vertical[data-row-index="${rowIndex}"]`))
-        let col = 1
-        row.cells.forEach((cell, cIdx) => {
-            col += row.spans[cIdx]
-            if (cIdx < row.cells.length - 1) {
-                const h = handles[cIdx]
-                if (h) h.style.gridColumn = String(col)
-            }
-        })
+    
+    get _columnPx () {
+        const rect = this.getBoundingClientRect()
+        const style = getComputedStyle(this)
+        const padL = parseFloat(style.paddingLeft) || 0
+        const padR = parseFloat(style.paddingRight) || 0
+        const gap = parseFloat(style.columnGap) || 0
+        const usable = rect.width - padL - padR
+        const totalGap = gap * (this._columnCount - 1)
+        return (usable - totalGap) / this._columnCount
     }
 
     _startReorder (e, cell) {
@@ -374,153 +371,218 @@ export default class Masonry extends KompElement {
         this.classList.add('reordering')
         cell.classList.add('dragging')
 
-        let dropTarget = null
+        // Snapshots for Escape revert and as the "from" reference for every
+        // move event (each pointermove computes the resulting layout fresh
+        // from the original state, not from the previous frame's state).
+        const cellPatternWas = this.cellPattern
+        const rowPatternWas = this.rowPattern
+        const N = this._columnCount
 
-        const indicator = createElement('komp-masonry-drop-indicator')
-        this.append(indicator)
+        const cellsAtStart = Array.from(this.cells)
+        const groupsAtStart = []
+        cellsAtStart.forEach(c => {
+            const r = parseInt(c.dataset.rowIndex, 10)
+            ;(groupsAtStart[r] = groupsAtStart[r] || []).push(c)
+        })
+        const rawMatrix = this._cellPatternToMatrix(cellPatternWas)
+        const expandedAtStart = groupsAtStart.map((_, r) => rawMatrix[r % rawMatrix.length].slice())
+        const fromRow = parseInt(cell.dataset.rowIndex, 10)
+        const fromCellIdx = parseInt(cell.dataset.cellIndex, 10)
+        const draggedSpan = expandedAtStart[fromRow][fromCellIdx]
+
+        const rect = cell.getBoundingClientRect()
+        const grabX = e.clientX - rect.left
+        const grabY = e.clientY - rect.top
+
+        const clone = cell.cloneNode(true)
+        clone.classList.add('komp-masonry-drag-clone')
+        clone.style.position = 'fixed'
+        clone.style.top = '0'
+        clone.style.left = '0'
+        clone.style.width = rect.width + 'px'
+        clone.style.height = rect.height + 'px'
+        clone.style.margin = '0'
+        clone.style.transform = `translate(${rect.left}px, ${rect.top}px)`
+        clone.style.gridColumn = '1'
+        clone.style.gridRow = '1'
+        this.prepend(clone)
+
+        const distribute = (count) => {
+            const base = Math.floor(N / count)
+            const rem = N - base * count
+            return Array.from({ length: count }, (_, i) => base + (i < rem ? 1 : 0))
+        }
+
+        let lastTargetKey = null
 
         const move = (ev) => {
-            const target = this._findDropTarget(ev.clientX, ev.clientY, cell)
-            dropTarget = target
-            this._renderDropIndicator(indicator, target)
+            clone.style.transform = `translate(${ev.clientX - grabX}px, ${ev.clientY - grabY}px)`
+            const target = this._findDropTarget(ev.clientX, ev.clientY, cell, Array.from(this.cells))
+            if (!target || target.type == 'self') return
+            const key = `${target.type}:${target.rowIndex ?? '-'}:${target.insertAt}`
+            if (key === lastTargetKey) return
+            lastTargetKey = key
+
+            // Apply transformation *from the original* state — never compound
+            // intermediate frames. This means every distinct target produces
+            // one cellPatternChanged repaint, not one per pointermove.
+            const groups = groupsAtStart.map(g => g.slice())
+            const expanded = expandedAtStart.map(r => r.slice())
+
+            groups[fromRow] = groups[fromRow].filter(c => c !== cell)
+            expanded[fromRow].splice(fromCellIdx, 1)
+
+            let toRow = target.type === 'into' ? target.rowIndex : target.insertAt
+
+            if (target.type === 'into' && fromRow === target.rowIndex) {
+                // Same-row reorder: keep the dragged cell's span, shuffle.
+                groups[toRow].splice(target.insertAt, 0, cell)
+                expanded[toRow].splice(target.insertAt, 0, draggedSpan)
+            } else {
+                // Source row: drop if empty, else redistribute evenly.
+                if (groups[fromRow].length === 0) {
+                    groups.splice(fromRow, 1)
+                    expanded.splice(fromRow, 1)
+                    if (toRow > fromRow) toRow--
+                } else {
+                    expanded[fromRow] = distribute(groups[fromRow].length)
+                }
+                if (target.type === 'into') {
+                    groups[toRow].splice(target.insertAt, 0, cell)
+                    expanded[toRow] = distribute(groups[toRow].length)
+                } else {
+                    // 'new' or 'between' — single-cell new row spanning all columns.
+                    groups.splice(toRow, 0, [cell])
+                    expanded.splice(toRow, 0, [N])
+                }
+            }
+
+            // Reorder DOM so each cell is followed by its handle. Snapshot the
+            // (cell, handle) pairs first because appendChild moves elements.
+            const flat = groups.flat()
+            const pairs = flat.map(c => {
+                const h = c.nextElementSibling?.localName === 'komp-masonry-handle' ? c.nextElementSibling : null
+                return [c, h]
+            })
+            pairs.forEach(([c, h]) => {
+                this.appendChild(c)
+                if (h) this.appendChild(h)
+            })
+
+            // One write per target change. cellPatternChanged repaints + updates dataset.
+            this.cellPattern = expanded.map(r => r.join(' ')).join(', ')
         }
-        const up = (ev) => {
+
+        const teardown = () => {
             window.removeEventListener('pointermove', move)
-            indicator.remove()
+            window.removeEventListener('pointerup', up)
+            window.removeEventListener('keydown', keydown)
+            clone.remove()
             cell.classList.remove('dragging')
             this.classList.remove('reordering')
-            this.releasePointerCapture(e.pointerId)
-            if (dropTarget) {
-                this._applyReorder(cell, dropTarget)
-                this.trigger('reorder', { detail: {
-                    cell,
-                    fromRow: dropTarget.fromRow,
-                    toRow: dropTarget.toRow
-                }})
+            try { this.releasePointerCapture(e.pointerId) } catch {}
+        }
+        const up = () => {
+            teardown()
+            if (cellPatternWas !== this.cellPattern) {
+                this.trigger('reorder', { detail: { cellPattern: this.cellPattern } })
             }
         }
+        const keydown = (ev) => {
+            if (ev.key !== 'Escape') return
+            // Revert: cellPatternChanged will repaint with the original pattern.
+            // The dragged cell + its handle still need to be moved back to their
+            // original DOM position so cellPatternChanged sees them in the right
+            // order; rebuild the start-of-drag DOM order and reapply.
+            const flat = groupsAtStart.flat()
+            const pairs = flat.map(c => {
+                const h = c.nextElementSibling?.localName === 'komp-masonry-handle' ? c.nextElementSibling : null
+                return [c, h]
+            })
+            pairs.forEach(([c, h]) => {
+                this.appendChild(c)
+                if (h) this.appendChild(h)
+            })
+            this.cellPattern = cellPatternWas
+            this.rowPattern = rowPatternWas
+            teardown()
+        }
         window.addEventListener('pointermove', move)
-        window.addEventListener('pointerup', up, { once: true })
+        window.addEventListener('pointerup', up)
+        window.addEventListener('keydown', keydown)
     }
 
-    _findDropTarget (clientX, clientY, draggedCell) {
-        const draggedRow = this._rows.findIndex(r => r.cells.includes(draggedCell))
+    /**
+     * Resolve a pointer position to a drop target.
+     * @returns {Object|null} `{ type: 'between', insertAt }` or
+     *   `{ type: 'into', rowIndex, insertIndex }` or null when outside.
+     */
+    _findDropTarget (clientX, clientY, draggedCell, cells) {
         const myRect = this.getBoundingClientRect()
         const localY = clientY - myRect.top
+        const localX = clientX - myRect.left
 
-        // For each row, compute its vertical extent from its cells
-        const rowMetrics = this._rows.map(row => {
-            const tops = row.cells.map(c => c.offsetTop)
-            const bottoms = row.cells.map(c => c.offsetTop + c.offsetHeight)
-            return { top: Math.min(...tops), bottom: Math.max(...bottoms) }
-        })
-
-        // Check between-row drop zones first (top of each row counts as "before")
+        // Group cells by their CSS row (dataset.rowIndex set by cellPatternChanged).
+        // Indexed array — row gaps would leave holes, but in practice rows are
+        // consecutive starting at 0.
+        const rows = []
+        for (const c of cells) {
+            const r = parseInt(c.dataset.rowIndex, 10)
+            ;(rows[r] = rows[r] || []).push(c)
+        }
+        const rowMetrics = rows.map(cs => ({
+            top: Math.min(...cs.map(c => c.offsetTop)),
+            bottom: Math.max(...cs.map(c => c.offsetTop + c.offsetHeight))
+        }))
+        
+        // Between-row zones (8px tolerance around row edges)
         for (let i = 0; i < rowMetrics.length; i++) {
             const m = rowMetrics[i]
-            const edge = i === 0 ? m.top : (rowMetrics[i - 1].bottom + m.top) / 2
             if (i === 0 && localY < m.top + 8) {
-                return { type: 'between', insertAt: 0, fromRow: draggedRow, toRow: 0 }
+                return { type: 'new', insertAt: 0 }
             }
+            const edge = i === 0 ? m.top : (rowMetrics[i - 1].bottom + m.top) / 2
             if (Math.abs(localY - edge) < 8) {
-                return { type: 'between', insertAt: i, fromRow: draggedRow, toRow: i }
+                return { type: 'between', insertAt: i }
             }
         }
         const last = rowMetrics[rowMetrics.length - 1]
         if (last && localY > last.bottom - 8) {
-            return { type: 'between', insertAt: rowMetrics.length, fromRow: draggedRow, toRow: rowMetrics.length }
+            return { type: 'new', insertAt: rowMetrics.length }
         }
 
-        // Otherwise drop into the row whose vertical band contains the pointer
+        // Into-row: find vertical band, then horizontal slot
         for (let i = 0; i < rowMetrics.length; i++) {
             const m = rowMetrics[i]
             if (localY >= m.top && localY <= m.bottom) {
-                return { type: 'into', rowIndex: i, fromRow: draggedRow, toRow: i }
+                if (rows[i].length == 1 && rows[i][0] == draggedCell) {
+                    return {type: 'self'}
+                }
+                const insertAt = this._computeInsertIndex(rows[i], draggedCell, localX)
+                return { type: 'into', rowIndex: i, insertAt }
             }
         }
         return null
     }
 
-    _renderDropIndicator (indicator, target) {
-        if (!target) {
-            indicator.style.display = 'none'
-            return
-        }
-        indicator.style.display = ''
-        if (target.type === 'between') {
-            indicator.classList.add('between')
-            indicator.classList.remove('into')
-            indicator.style.gridColumn = `1 / ${this._gridCount + 1}`
-            indicator.style.gridRow = String(Math.max(1, Math.min(this._rows.length, target.insertAt + 1)))
-            indicator.style.alignSelf = target.insertAt >= this._rows.length ? 'end' : 'start'
-        } else {
-            indicator.classList.add('into')
-            indicator.classList.remove('between')
-            indicator.style.gridColumn = `1 / ${this._gridCount + 1}`
-            indicator.style.gridRow = String(target.rowIndex + 1)
-            indicator.style.alignSelf = 'stretch'
-        }
-    }
-
-    _applyReorder (cell, target) {
-        const rows = this._rows
-        const fromRowIdx = rows.findIndex(r => r.cells.includes(cell))
-        if (fromRowIdx < 0) return
-        const fromRow = rows[fromRowIdx]
-        const fromCellIdx = fromRow.cells.indexOf(cell)
-
-        // Remove from source row
-        fromRow.cells.splice(fromCellIdx, 1)
-        fromRow.spans.splice(fromCellIdx, 1)
-
-        let destRow
-        let destRowIdx
-        if (target.type === 'between') {
-            destRow = { cells: [cell], spans: [this._gridCount] }
-            destRowIdx = target.insertAt
-            // Insert relative to fromRowIdx removal
-            if (fromRowIdx < destRowIdx) destRowIdx -= 1 // account for source-row shift if it's about to be empty (handled below)
-            rows.splice(target.insertAt, 0, destRow)
-        } else {
-            destRowIdx = target.rowIndex
-            destRow = rows[destRowIdx]
-            destRow.cells.push(cell)
-        }
-
-        // Drop empty source row
-        if (fromRow.cells.length === 0) {
-            const idx = rows.indexOf(fromRow)
-            rows.splice(idx, 1)
-        }
-
-        // Redistribute affected rows evenly across gridCount
-        const distribute = (row) => {
-            const n = row.cells.length
-            if (n === 0) return
-            const base = Math.floor(this._gridCount / n)
-            const remainder = this._gridCount - base * n
-            row.spans = row.cells.map((_, i) => base + (i < remainder ? 1 : 0))
-        }
-        if (rows.includes(fromRow)) distribute(fromRow)
-        if (target.type === 'into') distribute(destRow)
-
-        // Reorder DOM children to match row order, then persist via cellPattern + re-render
-        const flat = rows.flatMap(r => r.cells)
-        flat.forEach(c => this.append(c))
-        this._persistRowsToPattern()
-    }
-
     /**
-     * Encode the current `_rows` layout back into `cellPattern` and re-render.
-     * Used after reorder/resize so the new layout survives subsequent renders.
+     * Within `row`, find the index where `draggedCell` should be inserted
+     * given a cursor X (in masonry-local coordinates). After insertion the
+     * row will have N+1 cells (or N if the cell was already there) and
+     * redistribute evenly, so we treat the row as N+1 equal-width slots.
      */
-    _persistRowsToPattern () {
-        if (!this._rows) return
-        const newPattern = this._rows.map(r => r.spans.join(' ')).join(', ')
-        this._suppressRender = true
-        this.cellPattern = newPattern
-        this._suppressRender = false
-        this.render()
+    _computeInsertIndex (cells, draggedCell, localX) {
+        const otherCells = cells.filter(c => c !== draggedCell)
+        if (otherCells.length === 0) return 0
+        const lefts = otherCells.map(c => c.offsetLeft)
+        const rights = otherCells.map(c => c.offsetLeft + c.offsetWidth)
+        const rowLeft = Math.min(...lefts)
+        const rowRight = Math.max(...rights)
+        const K = otherCells.length + 1
+        const slotWidth = (rowRight - rowLeft) / K
+        if (slotWidth <= 0) return 0
+        const slot = Math.floor((localX - rowLeft) / slotWidth)
+        return Math.max(0, Math.min(K - 1, slot))
     }
 
     static style = `
@@ -530,7 +592,7 @@ export default class Masonry extends KompElement {
         }
         komp-masonry-handle {
             position: relative;
-            z-index: 2;
+            z-index: 5;
             background: transparent;
             touch-action: none;
         }
@@ -538,37 +600,52 @@ export default class Masonry extends KompElement {
             cursor: col-resize;
             justify-self: start;
             align-self: stretch;
-            width: 8px;
-            margin-left: -4px;
+            inline-size: 16px;
+            margin-inline-start: calc(-8px - var(--komp-masonry-column-gap, 0px) / 2);
         }
         komp-masonry-handle.horizontal {
             cursor: row-resize;
-            align-self: end;
             justify-self: stretch;
-            height: 8px;
-            margin-bottom: -4px;
+            align-self: end;
+            block-size: 16px;
+            margin-block-end: calc(-8px - var(--komp-masonry-row-gap, 0px) / 2);
         }
-        komp-masonry-handle:hover,
-        komp-masonry-handle.active {
-            background: rgba(0, 0, 255, 0.4);
+        komp-masonry-handle::after {
+            content: '';
+            position: absolute;
+            pointer-events: none;
+            background: transparent;
+            transition: background 100ms ease;
+        }
+        komp-masonry-handle.vertical::after {
+            inset-block: 0;
+            inset-inline-start: 7px;
+            inline-size: 2px;
+        }
+        komp-masonry-handle.horizontal::after {
+            inset-inline: 0;
+            inset-block-start: 7px;
+            block-size: 2px;
+        }
+        komp-masonry-handle:hover::after {
+            background: rgba(0, 0, 255, 0.5);
+        }
+        komp-masonry-handle.active::after {
+            background: rgba(0, 0, 255, 0.9);
         }
         komp-masonry.reordering > *:not(komp-masonry-handle):not(komp-masonry-drop-indicator) {
             pointer-events: none;
         }
         komp-masonry > .dragging {
-            opacity: 0.4;
+            opacity: 0.3;
         }
-        komp-masonry-drop-indicator {
+        .komp-masonry-drag-clone {
             pointer-events: none;
-            border: 2px dashed rgba(0, 0, 255, 0.6);
-            background: rgba(0, 0, 255, 0.05);
-            z-index: 3;
-        }
-        komp-masonry-drop-indicator.between {
-            border: none;
-            background: rgba(0, 0, 255, 0.6);
-            block-size: 4px;
-            margin-block-start: -2px;
+            opacity: 0.9;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+            z-index: 9999;
+            will-change: transform;
         }
     `
+    static { this.define() }
 }

--- a/lib/komps/masonry.js
+++ b/lib/komps/masonry.js
@@ -1,0 +1,574 @@
+/**
+ * A managed CSS-Grid masonry layout. Each direct child becomes a cell placed via spans
+ * derived from `cellPattern`. Pattern values are integer column counts (not fr units),
+ * separated by spaces with commas separating rows. The pattern repeats to cover all
+ * children. `rowPattern` lists row track heights and similarly repeats.
+ *
+ * @class Masonry
+ * @extends KompElement
+ *
+ * @param {Object} [options={}]
+ * @param {string} [options.cellPattern="1"] - Per-row cell column counts. Rows separated by `,`. Example: `"3 3 6, 6 6, 7 5, 12"`
+ * @param {string} [options.rowPattern="auto"] - Repeating row heights (any CSS row track value). Example: `"200px 100px auto"`
+ * @param {number} [options.gridCount] - Number of grid columns. Defaults to LCM of `cellPattern` row sums.
+ * @param {boolean} [options.resizable=false] - When true, render drag handles between cells (horizontal) and between rows (vertical) for live resizing
+ * @param {boolean} [options.reorderable=false] - When true, dragging a cell moves it to a new row; the source and destination rows redistribute their cells evenly across `gridCount`
+ * @param {string|HTMLElement|Array|Object} [options.content] - Initial children. Each becomes a cell.
+ *
+ * @fires Masonry#rendered
+ * @fires Masonry#resize
+ * @fires Masonry#reorder
+ *
+ * @example <caption>JS</caption>
+ * new Masonry({
+ *     cellPattern: '3 3 6, 6 6, 7 5, 12',
+ *     rowPattern: '200px 100px auto',
+ *     resizable: true,
+ *     reorderable: true,
+ *     content: items.map(i => createElement('div', { content: i.label }))
+ * })
+ *
+ * @example <caption>HTML</caption>
+ * <komp-masonry cellPattern="3 3 6, 6 6, 12" rowPattern="200px 100px auto">
+ *     <div>1</div>
+ *     <div>2</div>
+ *     <div>3</div>
+ *     <div>4</div>
+ *     <div>5</div>
+ *     <div>6</div>
+ * </komp-masonry>
+ */
+
+/**
+ * Fired after layout is computed and cells are placed
+ * @event Masonry#rendered
+ */
+
+/**
+ * Fired after a resize via handle. `event.detail` includes `{ axis, rowIndex, cellIndex, span, neighborSpan }` for column resize, or `{ axis, rowIndex, height }` for row resize.
+ * @event Masonry#resize
+ */
+
+/**
+ * Fired after a drag-reorder. `event.detail` includes `{ cell, fromRow, toRow }`
+ * @event Masonry#reorder
+ */
+
+import { content as setContent, createElement } from 'dolla';
+import KompElement from './element.js';
+
+function gcd (a, b) { return b === 0 ? a : gcd(b, a % b) }
+function lcm (a, b) { return (a * b) / gcd(a, b) }
+
+export default class Masonry extends KompElement {
+    static tagName = 'komp-masonry'
+    static { this.define() }
+
+    static assignableAttributes = {
+        cellPattern: { type: 'string', default: '1', null: false },
+        rowPattern: { type: 'string', default: 'auto', null: false },
+        gridCount: { type: 'number', default: null, null: true },
+        resizable: { type: 'boolean', default: false, null: false },
+        reorderable: { type: 'boolean', default: false, null: false }
+    }
+
+    static watch = ['cellPattern', 'rowPattern', 'gridCount', 'resizable', 'reorderable']
+    static events = ['rendered', 'resize', 'reorder']
+    static bindMethods = ['_onPointerDown']
+
+    constructor (attrs = {}) {
+        const initialContent = attrs.content
+        delete attrs.content
+        super(attrs)
+        this._initialContent = initialContent
+    }
+
+    initialize () {
+        super.initialize()
+        if (this._initialContent != null) {
+            setContent(this, this._initialContent)
+            this._initialContent = null
+        }
+        this.render()
+        this.addEventListener('pointerdown', this._onPointerDown)
+    }
+
+    changed (attribute) {
+        if (this._suppressRender) return
+        if (this.is_initialized && this.constructor.watch.includes(attribute)) {
+            this.render()
+        }
+    }
+
+    /**
+     * Direct children that aren't internal handle elements
+     * @returns {HTMLElement[]}
+     */
+    get cells () {
+        return Array.from(this.children).filter(c => c.localName !== 'komp-masonry-handle')
+    }
+
+    /**
+     * Replace cell content and re-render
+     * @param {*} value - dolla-shaped content
+     */
+    setContent (value) {
+        this._removeHandles()
+        setContent(this, value)
+        this.render()
+    }
+
+    parsePattern () {
+        return this.cellPattern.split(',').map(row =>
+            row.trim().split(/\s+/).map(v => parseInt(v, 10)).filter(n => !isNaN(n) && n > 0)
+        ).filter(row => row.length > 0)
+    }
+
+    parseRowPattern () {
+        return this.rowPattern.split(/\s+/).map(s => s.trim()).filter(Boolean)
+    }
+
+    /**
+     * Computed grid column count. Honors explicit `gridCount` or derives from
+     * the LCM of `cellPattern` row sums.
+     */
+    get computedGridCount () {
+        if (this.gridCount) return this.gridCount
+        const sums = this.parsePattern().map(row => row.reduce((a, b) => a + b, 0))
+        if (sums.length === 0) return 1
+        return sums.reduce((a, b) => lcm(a, b))
+    }
+
+    render () {
+        const cells = this.cells
+        const pattern = this.parsePattern()
+        const explicitGrid = this.gridCount
+        const baseGrid = explicitGrid || pattern.map(r => r.reduce((a, b) => a + b, 0)).reduce((a, b) => lcm(a, b), 1)
+        const gridCount = baseGrid
+
+        this._removeHandles()
+
+        if (pattern.length === 0 || cells.length === 0) {
+            this.style.display = 'grid'
+            this.style.gridTemplateColumns = `repeat(${gridCount}, 1fr)`
+            this.style.gridTemplateRows = ''
+            this.trigger('rendered')
+            return
+        }
+
+        // Walk pattern to assign each cell a row + span
+        const rows = []
+        let currentRow = null
+        let patternRowIdx = 0
+        let patternCellIdx = 0
+
+        const newRow = () => {
+            currentRow = { spans: [], cells: [] }
+            rows.push(currentRow)
+        }
+        newRow()
+
+        for (let i = 0; i < cells.length; i++) {
+            const cell = cells[i]
+            const span = pattern[patternRowIdx][patternCellIdx]
+            currentRow.spans.push(span)
+            currentRow.cells.push(cell)
+
+            patternCellIdx++
+            if (patternCellIdx >= pattern[patternRowIdx].length) {
+                patternRowIdx = (patternRowIdx + 1) % pattern.length
+                patternCellIdx = 0
+                if (i < cells.length - 1) newRow()
+            }
+        }
+
+        // Apply explicit grid placement
+        rows.forEach((row, rIdx) => {
+            let col = 1
+            row.cells.forEach((cell, cIdx) => {
+                const span = row.spans[cIdx]
+                cell.style.gridColumn = `${col} / span ${span}`
+                cell.style.gridRow = String(rIdx + 1)
+                col += span
+            })
+        })
+
+        // Set parent grid templates
+        const rp = this.parseRowPattern()
+        const expandedRows = Array.from({ length: rows.length }, (_, i) => rp[i % rp.length] || 'auto').join(' ')
+        this.style.display = 'grid'
+        this.style.gridTemplateColumns = `repeat(${gridCount}, 1fr)`
+        this.style.gridTemplateRows = expandedRows
+
+        this._rows = rows
+        this._gridCount = gridCount
+
+        if (this.resizable) this._renderHandles()
+
+        this.trigger('rendered')
+    }
+
+    _removeHandles () {
+        Array.from(this.querySelectorAll(':scope > komp-masonry-handle')).forEach(h => h.remove())
+    }
+
+    _renderHandles () {
+        const rows = this._rows
+        const gridCount = this._gridCount
+
+        rows.forEach((row, rIdx) => {
+            // Vertical handle between adjacent cells in a row (column resize)
+            let col = 1
+            row.cells.forEach((cell, cIdx) => {
+                col += row.spans[cIdx]
+                if (cIdx < row.cells.length - 1) {
+                    const handle = createElement('komp-masonry-handle', {
+                        class: 'vertical',
+                        data: { rowIndex: rIdx, cellIndex: cIdx },
+                        style: {
+                            gridColumn: String(col),
+                            gridRow: String(rIdx + 1)
+                        }
+                    })
+                    this.append(handle)
+                }
+            })
+            // Horizontal handle on the bottom edge (row resize), skip last row
+            if (rIdx < rows.length - 1) {
+                const handle = createElement('komp-masonry-handle', {
+                    class: 'horizontal',
+                    data: { rowIndex: rIdx },
+                    style: {
+                        gridColumn: `1 / ${gridCount + 1}`,
+                        gridRow: String(rIdx + 1)
+                    }
+                })
+                this.append(handle)
+            }
+        })
+    }
+
+    _onPointerDown (e) {
+        const handle = e.target.closest('komp-masonry-handle')
+        if (handle && this.resizable) {
+            this._startResize(e, handle)
+            return
+        }
+        if (this.reorderable) {
+            const cell = this.cells.find(c => c === e.target || c.contains(e.target))
+            if (cell) this._startReorder(e, cell)
+        }
+    }
+
+    _columnPx () {
+        const rect = this.getBoundingClientRect()
+        const style = getComputedStyle(this)
+        const padL = parseFloat(style.paddingLeft) || 0
+        const padR = parseFloat(style.paddingRight) || 0
+        const gap = parseFloat(style.columnGap) || 0
+        const usable = rect.width - padL - padR
+        const totalGap = gap * (this._gridCount - 1)
+        return (usable - totalGap) / this._gridCount
+    }
+
+    _startResize (e, handle) {
+        e.preventDefault()
+        this.setPointerCapture(e.pointerId)
+        handle.classList.add('active')
+
+        const isVertical = handle.classList.contains('vertical')
+        const rowIndex = parseInt(handle.dataset.rowIndex, 10)
+        const startX = e.clientX
+        const startY = e.clientY
+
+        if (isVertical) {
+            const cellIndex = parseInt(handle.dataset.cellIndex, 10)
+            const row = this._rows[rowIndex]
+            const cell = row.cells[cellIndex]
+            const startSpan = row.spans[cellIndex]
+            const startNeighborSpan = row.spans[cellIndex + 1]
+            const colPx = this._columnPx()
+            const totalSpan = startSpan + startNeighborSpan
+
+            const move = (ev) => {
+                const delta = Math.round((ev.clientX - startX) / colPx)
+                let newSpan = Math.min(Math.max(1, startSpan + delta), totalSpan - 1)
+                let newNeighborSpan = totalSpan - newSpan
+                row.spans[cellIndex] = newSpan
+                row.spans[cellIndex + 1] = newNeighborSpan
+                this._applyRowSpans(rowIndex)
+                this._repositionRowHandles(rowIndex)
+            }
+            const up = (ev) => {
+                window.removeEventListener('pointermove', move)
+                handle.classList.remove('active')
+                this.releasePointerCapture(e.pointerId)
+                this._persistRowsToPattern()
+                this.trigger('resize', { detail: {
+                    axis: 'column',
+                    rowIndex,
+                    cellIndex,
+                    span: row.spans[cellIndex],
+                    neighborSpan: row.spans[cellIndex + 1]
+                }})
+            }
+            window.addEventListener('pointermove', move)
+            window.addEventListener('pointerup', up, { once: true })
+        } else {
+            // Row height resize. Convert auto/derived height to pixels and grow/shrink.
+            const rp = this.parseRowPattern()
+            const tracks = this.style.gridTemplateRows.split(/\s+/)
+            const startHeight = this._measureRowHeight(rowIndex)
+            const move = (ev) => {
+                const newHeight = Math.max(10, startHeight + (ev.clientY - startY))
+                tracks[rowIndex] = newHeight + 'px'
+                this.style.gridTemplateRows = tracks.join(' ')
+            }
+            const up = (ev) => {
+                window.removeEventListener('pointermove', move)
+                handle.classList.remove('active')
+                this.releasePointerCapture(e.pointerId)
+                this.trigger('resize', { detail: {
+                    axis: 'row',
+                    rowIndex,
+                    height: parseFloat(tracks[rowIndex])
+                }})
+            }
+            window.addEventListener('pointermove', move)
+            window.addEventListener('pointerup', up, { once: true })
+        }
+    }
+
+    _measureRowHeight (rowIndex) {
+        const row = this._rows[rowIndex]
+        if (!row || row.cells.length === 0) return 0
+        return Math.max(...row.cells.map(c => c.offsetHeight))
+    }
+
+    _applyRowSpans (rowIndex) {
+        const row = this._rows[rowIndex]
+        let col = 1
+        row.cells.forEach((cell, cIdx) => {
+            const span = row.spans[cIdx]
+            cell.style.gridColumn = `${col} / span ${span}`
+            col += span
+        })
+    }
+
+    _repositionRowHandles (rowIndex) {
+        const row = this._rows[rowIndex]
+        const handles = Array.from(this.querySelectorAll(`:scope > komp-masonry-handle.vertical[data-row-index="${rowIndex}"]`))
+        let col = 1
+        row.cells.forEach((cell, cIdx) => {
+            col += row.spans[cIdx]
+            if (cIdx < row.cells.length - 1) {
+                const h = handles[cIdx]
+                if (h) h.style.gridColumn = String(col)
+            }
+        })
+    }
+
+    _startReorder (e, cell) {
+        e.preventDefault()
+        this.setPointerCapture(e.pointerId)
+        this.classList.add('reordering')
+        cell.classList.add('dragging')
+
+        let dropTarget = null
+
+        const indicator = createElement('komp-masonry-drop-indicator')
+        this.append(indicator)
+
+        const move = (ev) => {
+            const target = this._findDropTarget(ev.clientX, ev.clientY, cell)
+            dropTarget = target
+            this._renderDropIndicator(indicator, target)
+        }
+        const up = (ev) => {
+            window.removeEventListener('pointermove', move)
+            indicator.remove()
+            cell.classList.remove('dragging')
+            this.classList.remove('reordering')
+            this.releasePointerCapture(e.pointerId)
+            if (dropTarget) {
+                this._applyReorder(cell, dropTarget)
+                this.trigger('reorder', { detail: {
+                    cell,
+                    fromRow: dropTarget.fromRow,
+                    toRow: dropTarget.toRow
+                }})
+            }
+        }
+        window.addEventListener('pointermove', move)
+        window.addEventListener('pointerup', up, { once: true })
+    }
+
+    _findDropTarget (clientX, clientY, draggedCell) {
+        const draggedRow = this._rows.findIndex(r => r.cells.includes(draggedCell))
+        const myRect = this.getBoundingClientRect()
+        const localY = clientY - myRect.top
+
+        // For each row, compute its vertical extent from its cells
+        const rowMetrics = this._rows.map(row => {
+            const tops = row.cells.map(c => c.offsetTop)
+            const bottoms = row.cells.map(c => c.offsetTop + c.offsetHeight)
+            return { top: Math.min(...tops), bottom: Math.max(...bottoms) }
+        })
+
+        // Check between-row drop zones first (top of each row counts as "before")
+        for (let i = 0; i < rowMetrics.length; i++) {
+            const m = rowMetrics[i]
+            const edge = i === 0 ? m.top : (rowMetrics[i - 1].bottom + m.top) / 2
+            if (i === 0 && localY < m.top + 8) {
+                return { type: 'between', insertAt: 0, fromRow: draggedRow, toRow: 0 }
+            }
+            if (Math.abs(localY - edge) < 8) {
+                return { type: 'between', insertAt: i, fromRow: draggedRow, toRow: i }
+            }
+        }
+        const last = rowMetrics[rowMetrics.length - 1]
+        if (last && localY > last.bottom - 8) {
+            return { type: 'between', insertAt: rowMetrics.length, fromRow: draggedRow, toRow: rowMetrics.length }
+        }
+
+        // Otherwise drop into the row whose vertical band contains the pointer
+        for (let i = 0; i < rowMetrics.length; i++) {
+            const m = rowMetrics[i]
+            if (localY >= m.top && localY <= m.bottom) {
+                return { type: 'into', rowIndex: i, fromRow: draggedRow, toRow: i }
+            }
+        }
+        return null
+    }
+
+    _renderDropIndicator (indicator, target) {
+        if (!target) {
+            indicator.style.display = 'none'
+            return
+        }
+        indicator.style.display = ''
+        if (target.type === 'between') {
+            indicator.classList.add('between')
+            indicator.classList.remove('into')
+            indicator.style.gridColumn = `1 / ${this._gridCount + 1}`
+            indicator.style.gridRow = String(Math.max(1, Math.min(this._rows.length, target.insertAt + 1)))
+            indicator.style.alignSelf = target.insertAt >= this._rows.length ? 'end' : 'start'
+        } else {
+            indicator.classList.add('into')
+            indicator.classList.remove('between')
+            indicator.style.gridColumn = `1 / ${this._gridCount + 1}`
+            indicator.style.gridRow = String(target.rowIndex + 1)
+            indicator.style.alignSelf = 'stretch'
+        }
+    }
+
+    _applyReorder (cell, target) {
+        const rows = this._rows
+        const fromRowIdx = rows.findIndex(r => r.cells.includes(cell))
+        if (fromRowIdx < 0) return
+        const fromRow = rows[fromRowIdx]
+        const fromCellIdx = fromRow.cells.indexOf(cell)
+
+        // Remove from source row
+        fromRow.cells.splice(fromCellIdx, 1)
+        fromRow.spans.splice(fromCellIdx, 1)
+
+        let destRow
+        let destRowIdx
+        if (target.type === 'between') {
+            destRow = { cells: [cell], spans: [this._gridCount] }
+            destRowIdx = target.insertAt
+            // Insert relative to fromRowIdx removal
+            if (fromRowIdx < destRowIdx) destRowIdx -= 1 // account for source-row shift if it's about to be empty (handled below)
+            rows.splice(target.insertAt, 0, destRow)
+        } else {
+            destRowIdx = target.rowIndex
+            destRow = rows[destRowIdx]
+            destRow.cells.push(cell)
+        }
+
+        // Drop empty source row
+        if (fromRow.cells.length === 0) {
+            const idx = rows.indexOf(fromRow)
+            rows.splice(idx, 1)
+        }
+
+        // Redistribute affected rows evenly across gridCount
+        const distribute = (row) => {
+            const n = row.cells.length
+            if (n === 0) return
+            const base = Math.floor(this._gridCount / n)
+            const remainder = this._gridCount - base * n
+            row.spans = row.cells.map((_, i) => base + (i < remainder ? 1 : 0))
+        }
+        if (rows.includes(fromRow)) distribute(fromRow)
+        if (target.type === 'into') distribute(destRow)
+
+        // Reorder DOM children to match row order, then persist via cellPattern + re-render
+        const flat = rows.flatMap(r => r.cells)
+        flat.forEach(c => this.append(c))
+        this._persistRowsToPattern()
+    }
+
+    /**
+     * Encode the current `_rows` layout back into `cellPattern` and re-render.
+     * Used after reorder/resize so the new layout survives subsequent renders.
+     */
+    _persistRowsToPattern () {
+        if (!this._rows) return
+        const newPattern = this._rows.map(r => r.spans.join(' ')).join(', ')
+        this._suppressRender = true
+        this.cellPattern = newPattern
+        this._suppressRender = false
+        this.render()
+    }
+
+    static style = `
+        komp-masonry {
+            display: grid;
+            position: relative;
+        }
+        komp-masonry-handle {
+            position: relative;
+            z-index: 2;
+            background: transparent;
+            touch-action: none;
+        }
+        komp-masonry-handle.vertical {
+            cursor: col-resize;
+            justify-self: start;
+            align-self: stretch;
+            width: 8px;
+            margin-left: -4px;
+        }
+        komp-masonry-handle.horizontal {
+            cursor: row-resize;
+            align-self: end;
+            justify-self: stretch;
+            height: 8px;
+            margin-bottom: -4px;
+        }
+        komp-masonry-handle:hover,
+        komp-masonry-handle.active {
+            background: rgba(0, 0, 255, 0.4);
+        }
+        komp-masonry.reordering > *:not(komp-masonry-handle):not(komp-masonry-drop-indicator) {
+            pointer-events: none;
+        }
+        komp-masonry > .dragging {
+            opacity: 0.4;
+        }
+        komp-masonry-drop-indicator {
+            pointer-events: none;
+            border: 2px dashed rgba(0, 0, 255, 0.6);
+            background: rgba(0, 0, 255, 0.05);
+            z-index: 3;
+        }
+        komp-masonry-drop-indicator.between {
+            border: none;
+            background: rgba(0, 0, 255, 0.6);
+            block-size: 4px;
+            margin-block-start: -2px;
+        }
+    `
+}

--- a/lib/komps/masonry.js
+++ b/lib/komps/masonry.js
@@ -200,12 +200,20 @@ export default class Masonry extends KompElement {
 
             if (this.resizable) {
                 if (cell.handle) {
-                    // Handle sits at the column line *after* the cell.
-                    cell.handle.style.gridArea = `${cssRow} / ${cssCol + span} / span 1 / span 1`
+                    const isLastInRow = cellInRow === matrix[matrixRow].length - 1
+                    // Non-last handle sits in the implicit column line *after* the cell
+                    // and is centered on the gap. The last-in-row handle would land
+                    // outside the explicit grid (creating an implicit track) so we
+                    // place it in the cell's final column instead and anchor it to
+                    // the right edge via the `.last-in-row` style.
+                    cell.handle.style.gridArea = isLastInRow
+                        ? `${cssRow} / ${cssCol + span - 1} / span 1 / span 1`
+                        : `${cssRow} / ${cssCol + span} / span 1 / span 1`
+                    cell.handle.classList.toggle('last-in-row', isLastInRow)
                     cell.handle.dataset.rowIndex = cssRow - 1
                     cell.handle.dataset.cellIndex = cellInRow
-                    // Last cell in a row has no right-edge boundary to resize.
-                    cell.handle.toggleAttribute('hidden', cellInRow === matrix[matrixRow].length - 1)
+                    // Only hide when there's no neighbor at all (single-cell row).
+                    cell.handle.toggleAttribute('hidden', matrix[matrixRow].length === 1)
                 }
             }
 
@@ -279,17 +287,31 @@ export default class Masonry extends KompElement {
             const patternMatrix = this._cellPatternToMatrix()
             const cellIndex = parseInt(handle.dataset.cellIndex, 10)
             const rowPattern = patternMatrix[rowIndex]
-            const cell = handle.cell
+            const isLastInRow = cellIndex === rowPattern.length - 1
             const startSpan = rowPattern[cellIndex]
-            const startNeighborSpan = rowPattern[cellIndex + 1]
-            const totalSpan = startSpan + startNeighborSpan
+
+            // Non-last handle splits the combined span of cells[cellIndex] and
+            // cells[cellIndex+1] — total row width stays the same.
+            // Last handle resizes the last cell against the row's column budget;
+            // the row may shrink below columnCount, leaving empty columns on the right.
+            // Pin columnCount on a last-handle drag so the LCM recompute in
+            // cellPatternChanged doesn't re-normalize the row back to full width.
+            let totalSpan, maxSpan
+            if (isLastInRow) {
+                if (this.columnCount == null) this.columnCount = this._columnCount
+                const otherCellsSum = rowPattern.reduce((s, sp, i) => i === cellIndex ? s : s + sp, 0)
+                maxSpan = this._columnCount - otherCellsSum
+                if (maxSpan < 1) return
+            } else {
+                totalSpan = startSpan + rowPattern[cellIndex + 1]
+                maxSpan = totalSpan - 1
+            }
 
             const move = (ev) => {
                 const delta = Math.round((ev.clientX - startX) / colPx)
-                let newSpan = Math.min(Math.max(1, startSpan + delta), totalSpan - 1)
-                let newNeighborSpan = totalSpan - newSpan
+                const newSpan = Math.min(Math.max(1, startSpan + delta), maxSpan)
                 rowPattern[cellIndex] = newSpan
-                rowPattern[cellIndex + 1] = newNeighborSpan
+                if (!isLastInRow) rowPattern[cellIndex + 1] = totalSpan - newSpan
                 this.cellPattern = this._cellMatrixToPattern(patternMatrix)
             }
             const up = (ev) => {
@@ -303,7 +325,7 @@ export default class Masonry extends KompElement {
                     rowIndex,
                     cellIndex,
                     span: rowPattern[cellIndex],
-                    neighborSpan: rowPattern[cellIndex + 1]
+                    neighborSpan: isLastInRow ? null : rowPattern[cellIndex + 1]
                 }})
             }
             window.addEventListener('pointermove', move)
@@ -590,6 +612,9 @@ export default class Masonry extends KompElement {
             display: grid;
             position: relative;
         }
+        komp-masonry.reordering {
+            cursor: grabbing;
+        }
         komp-masonry-handle {
             position: relative;
             z-index: 5;
@@ -602,6 +627,11 @@ export default class Masonry extends KompElement {
             align-self: stretch;
             inline-size: 16px;
             margin-inline-start: calc(-8px - var(--komp-masonry-column-gap, 0px) / 2);
+        }
+        komp-masonry-handle.vertical.last-in-row {
+            justify-self: end;
+            margin-inline-start: 0;
+            margin-inline-end: -8px;
         }
         komp-masonry-handle.horizontal {
             cursor: row-resize;
@@ -638,6 +668,7 @@ export default class Masonry extends KompElement {
         }
         komp-masonry > .dragging {
             opacity: 0.3;
+            cursor: grabbing;
         }
         .komp-masonry-drag-clone {
             pointer-events: none;

--- a/lib/support.js
+++ b/lib/support.js
@@ -140,7 +140,7 @@ export function groupBy(array, key) {
     array.forEach(x => {
         let xKey
         if (isFunction(key)) {
-            xKey = results[key(x)]
+            xKey = key(x)
         } else {
             xKey = result(x, key)
         }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "./floater": "./lib/komps/floater.js",
     "./form": "./lib/komps/form.js",
     "./input": "./lib/komps/input.js",
+    "./masonry": "./lib/komps/masonry.js",
     "./modal": "./lib/komps/modal.js",
     "./notification-center": "./lib/komps/notification-center.js",
     "./resizer": "./lib/komps/resizer.js",


### PR DESCRIPTION
## Summary

- New `Masonry` component (`komp-masonry`): a managed CSS-Grid layout where `cellPattern` declares per-row cell column counts and `rowPattern` declares repeating row track heights. `gridCount` defaults to the LCM of `cellPattern` row sums.
- `resizable` adds drag handles between cells (snap to integer grid columns) and between rows (pixel-snapped row heights).
- `reorderable` lets the user drag a cell into a different row; the destination row redistributes its cells evenly across `gridCount` and the source row redistributes too. The new layout is encoded back into `cellPattern` so it survives subsequent re-renders.

For the example `cellPattern="3 3 6, 6 6, 7 5, 12"`, dragging the `7` cell into the second row produces `"3 3 6, 4 4 4, 12, 12"` — destination row evenly redistributes 3 cells across the 12-col grid; the orphaned `5` becomes a full-width row.

## Test plan

- [ ] Open `/demo/masonry` — initial 8-cell layout matches `3 3 6, 6 6, 7 5, 12`
- [ ] Drag right edge of a cell to resize; adjacent cell shrinks; snaps to integer columns
- [ ] Drag a row divider to resize row height
- [ ] Drag a cell into a different row; destination row redistributes evenly; source row redistributes
- [ ] Drag a cell to between-row drop zone; new row of full width is inserted
- [ ] After interaction, inspect `cellPattern` attribute reflects the new layout
- [ ] `npm test` still passes
- [ ] `npm run docs` builds without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)