### PR TITLE
fix scanPrototypesFor cache when class init is in flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **Row-level readonly** — `TableRow` accepts a `readonly` function (called with the record) and a new `renderCell(column, record, options)` method that resolves it per-record before delegating to `column.renderCell`. `Spreadsheet` exposes a matching `readonly` attribute and forwards it to each row, so a single `readonly: record => record.archived` declaration makes all cells in matching rows non-editable. `Table.renderRow` now accepts an optional `attrs` object that is spread into the row's construction options (#28).
 - **SearchField default results** — `SearchField` accepts a `defaultResults` option (Array or async function) shown when the query is below `minLength`, including on focus before the user has typed. Items have the same shape as those returned from `search`, so `result` and `select` apply unchanged. Async functions are resolved once and cached on the instance.
 
+### Bug Fixes
+
+- **`scanPrototypesFor` cache invalidation** — Cache entries now invalidate when the constructor's own-property status for a key flips. Without this, an instance constructed during class initialization (e.g. when `customElements.define` upgrades a pre-existing element before the subclass's `static <key> = ...` field has run) would lock in a result missing the subclass's own value, and every subsequent instance would inherit the wrong merged metadata.
+
 ### Breaking Changes
 
 - **Tooltip auto-wiring removed** — `new Tooltip({ anchor, content })` no longer attaches mouseenter/mouseleave/focus/blur/keydown listeners to the anchor. The `enable()` / `disable()` methods and the `enabled` option are removed. Use `Tooltip.delegate(container, defaults)` to install a single delegated listener that shows tooltips for any descendant with `data-tooltip` (or `title`, which is stripped to suppress the native browser tooltip). Per-element options are read from `data-tooltip-*` attributes.

--- a/lib/support.js
+++ b/lib/support.js
@@ -61,6 +61,12 @@ export function eachPrototype(obj, fn) {
  * (e.g. plugins calling `this.events.push(...)`) remain visible. Treat the
  * returned array as read-only.
  *
+ * Cache entries are invalidated when `obj.hasOwnProperty(key)` flips, which
+ * covers the case where an instance is constructed during class
+ * initialization (e.g. `customElements.define` upgrades an existing element
+ * before the subclass's `static <key> = ...` field has run) and the cache
+ * would otherwise lock in a result missing the subclass's own value.
+ *
  * @param {Object} obj - The object to climb the property chain with
  * @param {string} key - The property name to find on each prototype
  * @returns {Array} - An array consisting of the property for each prototype
@@ -72,8 +78,10 @@ export function scanPrototypesFor(obj, key) {
         cache = new Map()
         _scanPrototypesCache.set(obj, cache)
     }
-    if (cache.has(key)) {
-        return cache.get(key)
+    const own = obj.hasOwnProperty(key)
+    const cached = cache.get(key)
+    if (cached && cached.own === own) {
+        return cached.values
     }
     const values = []
     eachPrototype(obj, p => {
@@ -81,7 +89,7 @@ export function scanPrototypesFor(obj, key) {
             values.push(p[key])
         }
     })
-    cache.set(key, values)
+    cache.set(key, { own, values })
     return values
 }
 

--- a/test/supportTest.js
+++ b/test/supportTest.js
@@ -1,0 +1,43 @@
+import { scanPrototypesFor } from '../lib/support.js';
+import * as assert from 'assert';
+
+describe('scanPrototypesFor', function () {
+
+    it('walks the prototype chain collecting own values per prototype', function () {
+        class A { static items = [1] }
+        class B extends A { static items = [2] }
+        class C extends B {}
+
+        assert.deepEqual(scanPrototypesFor(A, 'items'), [[1]])
+        assert.deepEqual(scanPrototypesFor(B, 'items'), [[2], [1]])
+        assert.deepEqual(scanPrototypesFor(C, 'items'), [[2], [1]])
+    })
+
+    it('memoizes repeated calls for the same (constructor, key) pair', function () {
+        class A { static items = [1] }
+        const first = scanPrototypesFor(A, 'items')
+        const second = scanPrototypesFor(A, 'items')
+        assert.strictEqual(first, second)
+    })
+
+    // Regression: when `customElements.define` triggers an upgrade mid-class-body,
+    // the constructor runs before the subclass's `static <key> = ...` line. The
+    // cache previously locked in the parent-only result and never recovered.
+    it('invalidates the cache when own-property status flips after first scan', function () {
+        class A { static items = [1] }
+        class B extends A {}
+
+        assert.deepEqual(scanPrototypesFor(B, 'items'), [[1]])
+
+        B.items = [2]
+        assert.deepEqual(scanPrototypesFor(B, 'items'), [[2], [1]])
+        assert.deepEqual(scanPrototypesFor(B, 'items'), [[2], [1]])
+    })
+
+    it('preserves in-place mutations to cached values (plugin pattern)', function () {
+        class A { static events = ['a'] }
+        const first = scanPrototypesFor(A, 'events')
+        first[0].push('b')
+        assert.deepEqual(scanPrototypesFor(A, 'events'), [['a', 'b']])
+    })
+})


### PR DESCRIPTION
## Summary

Fixes a regression introduced by 7d67a95 (`memoize scanPrototypesFor to avoid per-instance prototype walks`). The memoization caches the merged prototype-chain values per `(constructor, key)` pair, but when `customElements.define` (called by `static { this.define() }`) upgrades a pre-existing element mid-class-body, the constructor fires **before** the subclass's `static <key> = ...` field initializers run. The first scan caches a result missing the subclass's own value, and every subsequent instance then inherits the wrong merged metadata — e.g. an empty `assignableAttributes`.

Discovered when adding the new `Masonry` component (#36): if a `<komp-masonry>` element exists in the DOM at script load, the upgrade triggers the constructor before `static assignableAttributes = {...}` runs, and the cache locks in `[{}]` (just `KompElement`'s default).

The fix tracks `obj.hasOwnProperty(key)` alongside each cached entry and invalidates when it flips. Plugin-style in-place mutations to the cached arrays still propagate, so the existing `this.events.push(...)` pattern continues to work.

## Test plan

- [x] `npm test` — 37 passing, including new `supportTest.js` regression coverage
- [ ] In a project that hits the original bug (e.g. `<komp-masonry>` rendered before the script imports), confirm `assignableAttributes` are now resolved on first instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)