### PR TITLE
Backport: fix scanPrototypesFor cache when class init is in flight

### DIFF
--- a/lib/support.js
+++ b/lib/support.js
@@ -61,6 +61,12 @@ export function eachPrototype(obj, fn) {
  * (e.g. plugins calling `this.events.push(...)`) remain visible. Treat the
  * returned array as read-only.
  *
+ * Cache entries are invalidated when `obj.hasOwnProperty(key)` flips, which
+ * covers the case where an instance is constructed during class
+ * initialization (e.g. `customElements.define` upgrades an existing element
+ * before the subclass's `static <key> = ...` field has run) and the cache
+ * would otherwise lock in a result missing the subclass's own value.
+ *
  * @param {Object} obj - The object to climb the property chain with
  * @param {string} key - The property name to find on each prototype
  * @returns {Array} - An array consisting of the property for each prototype
@@ -72,8 +78,10 @@ export function scanPrototypesFor(obj, key) {
         cache = new Map()
         _scanPrototypesCache.set(obj, cache)
     }
-    if (cache.has(key)) {
-        return cache.get(key)
+    const own = obj.hasOwnProperty(key)
+    const cached = cache.get(key)
+    if (cached && cached.own === own) {
+        return cached.values
     }
     const values = []
     eachPrototype(obj, p => {
@@ -81,7 +89,7 @@ export function scanPrototypesFor(obj, key) {
             values.push(p[key])
         }
     })
-    cache.set(key, values)
+    cache.set(key, { own, values })
     return values
 }
 

--- a/test/supportTest.js
+++ b/test/supportTest.js
@@ -1,0 +1,43 @@
+import { scanPrototypesFor } from '../lib/support.js';
+import * as assert from 'assert';
+
+describe('scanPrototypesFor', function () {
+
+    it('walks the prototype chain collecting own values per prototype', function () {
+        class A { static items = [1] }
+        class B extends A { static items = [2] }
+        class C extends B {}
+
+        assert.deepEqual(scanPrototypesFor(A, 'items'), [[1]])
+        assert.deepEqual(scanPrototypesFor(B, 'items'), [[2], [1]])
+        assert.deepEqual(scanPrototypesFor(C, 'items'), [[2], [1]])
+    })
+
+    it('memoizes repeated calls for the same (constructor, key) pair', function () {
+        class A { static items = [1] }
+        const first = scanPrototypesFor(A, 'items')
+        const second = scanPrototypesFor(A, 'items')
+        assert.strictEqual(first, second)
+    })
+
+    // Regression: when `customElements.define` triggers an upgrade mid-class-body,
+    // the constructor runs before the subclass's `static <key> = ...` line. The
+    // cache previously locked in the parent-only result and never recovered.
+    it('invalidates the cache when own-property status flips after first scan', function () {
+        class A { static items = [1] }
+        class B extends A {}
+
+        assert.deepEqual(scanPrototypesFor(B, 'items'), [[1]])
+
+        B.items = [2]
+        assert.deepEqual(scanPrototypesFor(B, 'items'), [[2], [1]])
+        assert.deepEqual(scanPrototypesFor(B, 'items'), [[2], [1]])
+    })
+
+    it('preserves in-place mutations to cached values (plugin pattern)', function () {
+        class A { static events = ['a'] }
+        const first = scanPrototypesFor(A, 'events')
+        first[0].push('b')
+        assert.deepEqual(scanPrototypesFor(A, 'events'), [['a', 'b']])
+    })
+})


### PR DESCRIPTION
## Summary
- Backports #37 (commit 0606b0b) onto the 1.x line.
- Tracks each cached `scanPrototypesFor` entry alongside the constructor's `hasOwnProperty(key)` status, and invalidates when it flips. Without this, an instance constructed mid-class-init (e.g. `customElements.define` upgrading a pre-existing element before the subclass's `static <key> = ...` field has run) locks in a result missing the subclass's own value, and every subsequent instance inherits the wrong merged metadata.
- Adds the regression test in `test/supportTest.js`.
- Drops the `CHANGELOG.md` hunk to match the prior 1.x backports (#30, #35).

## Test plan
- [x] `npm test` — full suite passes (36 passing), including the four new `scanPrototypesFor` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)