### PR TITLE
move static define() block to end of class body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **Row-level readonly** — `TableRow` accepts a `readonly` function (called with the record) and a new `renderCell(column, record, options)` method that resolves it per-record before delegating to `column.renderCell`. `Spreadsheet` exposes a matching `readonly` attribute and forwards it to each row, so a single `readonly: record => record.archived` declaration makes all cells in matching rows non-editable. `Table.renderRow` now accepts an optional `attrs` object that is spread into the row's construction options (#28).
 - **SearchField default results** — `SearchField` accepts a `defaultResults` option (Array or async function) shown when the query is below `minLength`, including on focus before the user has typed. Items have the same shape as those returned from `search`, so `result` and `select` apply unchanged. Async functions are resolved once and cached on the instance.
 
+### Bug Fixes
+
+- **Component registration ordering** — Moved every `static { this.define() }` block to the end of its class body, so `customElements.define` always runs after every other static field initializer. Without this, a pre-existing element in the DOM at script load could trigger a constructor on a class whose `assignableAttributes` (and other statics like `observer`) haven't initialized yet. Documented the requirement on `KompElement.define`'s JSDoc and in `CLAUDE.md` so subclasses follow the same pattern.
+
 ### Breaking Changes
 
 - **Tooltip auto-wiring removed** — `new Tooltip({ anchor, content })` no longer attaches mouseenter/mouseleave/focus/blur/keydown listeners to the anchor. The `enable()` / `disable()` methods and the `enabled` option are removed. Use `Tooltip.delegate(container, defaults)` to install a single delegated listener that shows tooltips for any descendant with `data-tooltip` (or `title`, which is stripped to suppress the native browser tooltip). Per-element options are read from `data-tooltip-*` attributes.

--- a/lib/komps/auto-grid.js
+++ b/lib/komps/auto-grid.js
@@ -19,7 +19,6 @@
 import KompElement from './element.js';
 export default class AutoGrid extends KompElement {
     static tagName = 'auto-grid'
-    static { this.define() }
 
     static observer = new ResizeObserver(entries => {
         entries.forEach(entry => entry.target.resize())
@@ -96,5 +95,7 @@ export default class AutoGrid extends KompElement {
             grid-template-columns: auto;
         }
     `
+
+    static { this.define() }
 }
 

--- a/lib/komps/content-area.js
+++ b/lib/komps/content-area.js
@@ -28,7 +28,6 @@ import FormField from './form-field.js';
 
 export default class ContentArea extends FormField {
     static tagName = "komp-content-area"
-    static { this.define() }
 
     static assignableAttributes = {
         name: { type: 'string', default: null, null: true }
@@ -111,4 +110,6 @@ export default class ContentArea extends FormField {
             min-width: 4ch;
         }
     `
+
+    static { this.define() }
 }

--- a/lib/komps/dropdown.js
+++ b/lib/komps/dropdown.js
@@ -29,7 +29,6 @@ import Floater from './floater.js';
 
 export default class Dropdown extends Floater {
     static tagName = 'komp-dropdown'
-    static { this.define() }
 
     static watch = ['anchor']
     
@@ -157,4 +156,5 @@ export default class Dropdown extends Floater {
         }
     }
 
+    static { this.define() }
 }

--- a/lib/komps/dropzone.js
+++ b/lib/komps/dropzone.js
@@ -32,7 +32,6 @@ import KompElement from './element.js';
 
 export default class Dropzone extends KompElement {
     static tagName = "komp-dropzone"
-    static { this.define() }
 
     static assignableAttributes = {
         enabled: { type: 'boolean', default: true, null: false },
@@ -202,4 +201,6 @@ export default class Dropzone extends KompElement {
             color: black;
         }
     `
+
+    static { this.define() }
 }

--- a/lib/komps/element.js
+++ b/lib/komps/element.js
@@ -73,6 +73,29 @@ export default class KompElement extends HTMLElement {
 
     /**
      * Register this component as a custom element. Safe to call multiple times.
+     *
+     * **Placement matters.** Invoke this from a `static { ... }` block placed at
+     * the **end** of the class body, after every other static field initializer
+     * (`assignableAttributes`, `events`, `style`, etc). `customElements.define`
+     * synchronously upgrades any pre-existing elements with the registered tag
+     * present in the DOM, which runs the constructor — and the constructor
+     * needs the class's static metadata to already exist. Calling `define()`
+     * mid-class-body (e.g. right after `static tagName = ...`) lets that
+     * upgrade fire before the rest of the statics initialize, which produces
+     * an instance with empty `assignableAttributes` and may also throw if a
+     * later `static observer = ...` hasn't run yet.
+     *
+     * Recommended pattern:
+     *
+     *     export default class MyComponent extends KompElement {
+     *         static tagName = 'my-component'
+     *         static assignableAttributes = { ... }
+     *         static events = [ ... ]
+     *         static style = `...`
+     *         // ... methods ...
+     *         static { this.define() }
+     *     }
+     *
      * @param {string} [tagName] - optional override for the tag name (defaults to static tagName)
      */
     static define(tagName) {

--- a/lib/komps/floater.js
+++ b/lib/komps/floater.js
@@ -82,7 +82,6 @@ import KompElement from './element.js';
 export default class Floater extends KompElement {
     static tagName = 'komp-floater';
     static activeFloaters = {};
-    static { this.define() }
 
     static assignableAttributes = {
         anchor: {
@@ -401,6 +400,6 @@ export default class Floater extends KompElement {
             height: var(--arrow-size, 1px);
         }
     `
-}
-if (!window.customElements.get('komp-floater')) {
+
+    static { this.define() }
 }

--- a/lib/komps/form-field.js
+++ b/lib/komps/form-field.js
@@ -9,7 +9,9 @@
  * @example
  * class MyInput extends FormField {
  *     static tagName = 'my-input'
- *     static { this.define() }
+ *     static assignableAttributes = { ... }
+ *     // ... other statics, methods ...
+ *     static { this.define() }   // must be the last static — see KompElement.define
  * }
  */
 

--- a/lib/komps/modal.js
+++ b/lib/komps/modal.js
@@ -23,7 +23,6 @@ import KompElement from './element.js';
 export default class Modal extends KompElement {
 
     static tagName = "komp-modal";
-    static { this.define() }
 
     constructor (...args) {
         super(...args)
@@ -179,4 +178,6 @@ export default class Modal extends KompElement {
             color: blue;
         }
     `}
+
+    static { this.define() }
 }

--- a/lib/komps/notification-center.js
+++ b/lib/komps/notification-center.js
@@ -41,7 +41,6 @@ import Notification from './notification-center/notification.js';
 
 export default class NotificationCenter extends KompElement {
     static tagName = 'komp-notification-center'
-    static { this.define() }
 
     static assignableAttributes = Notification.assignableAttributes
     
@@ -112,4 +111,6 @@ export default class NotificationCenter extends KompElement {
             opacity: 1;
         }
     `
+
+    static { this.define() }
 }

--- a/lib/komps/notification-center/notification.js
+++ b/lib/komps/notification-center/notification.js
@@ -14,7 +14,6 @@ import { append, content, listenerElement, createElement } from 'dolla';
 import KompElement from '../element.js';
 export default class Notification extends KompElement {
     static tagName = 'komp-notification'
-    static { this.define() }
 
     static assignableAttributes = {
         timeout: { type: 'number', default: 5000, null: false },
@@ -92,4 +91,6 @@ export default class Notification extends KompElement {
     restartTimeout () {
         this.timer.play()
     }
+
+    static { this.define() }
 }

--- a/lib/komps/resizer.js
+++ b/lib/komps/resizer.js
@@ -51,7 +51,6 @@ const DIRECTIONS_ORDER = ['top', 'right', 'bottom', 'left']
 
 export default class Resizer extends KompElement {
     static tagName = 'komp-resizer'
-    static { this.define() }
 
     static _targetMap = new Map()
     static observer = new ResizeObserver(entries => {
@@ -377,5 +376,7 @@ export default class Resizer extends KompElement {
             writing-mode: vertical-lr;
         }
     `
+
+    static { this.define() }
 }
 

--- a/lib/komps/search-field.js
+++ b/lib/komps/search-field.js
@@ -70,7 +70,6 @@ import { debounce, result } from '../support.js';
 export default class SearchField extends KompElement {
 
     static tagName = 'komp-search-field'
-    static { this.define() }
     static assignableMethods = ['renderResult', 'renderResults']
     static events = ['select', 'search', 'results']
     
@@ -313,5 +312,7 @@ export default class SearchField extends KompElement {
             justify-content: center;
         }
     `
+
+    static { this.define() }
 }
 

--- a/lib/komps/select.js
+++ b/lib/komps/select.js
@@ -27,7 +27,6 @@ import { dig, bury } from '../support.js';
 
 export default class Select extends FormField {
     static tagName = 'komp-select'
-    static { this.define() }
 
     static assignableAttributes = {
         name: { type: 'string', default: null, null: true },
@@ -301,4 +300,6 @@ export default class Select extends FormField {
             }
         }
     `
+
+    static { this.define() }
 }

--- a/lib/komps/spreadsheet.js
+++ b/lib/komps/spreadsheet.js
@@ -52,7 +52,6 @@ import { reorderable, resizable } from './plugins.js';
 
 export default class Spreadsheet extends Table {
     static tagName = 'komp-spreadsheet'
-    static { this.define() }
 
     static assignableAttributes = {
         scrollSnap: { type: 'boolean', default: false, null: false },
@@ -609,6 +608,8 @@ export default class Spreadsheet extends Table {
             padding: 1em;
         }
     `
+
+    static { this.define() }
 }
 Spreadsheet.include(resizable)
 Spreadsheet.include(reorderable)

--- a/lib/komps/spreadsheet/cell.js
+++ b/lib/komps/spreadsheet/cell.js
@@ -23,7 +23,6 @@ import TableCell from '../table/cell.js';
 
 export default class SpreadsheetCell extends TableCell {
     static tagName = 'komp-spreadsheet-cell';
-    static { this.define() }
 
     static assignableAttributes = {
         readonly: { type: 'boolean', default: false, null: false }
@@ -232,4 +231,6 @@ export default class SpreadsheetCell extends TableCell {
     contextMenu (menu) {
         return this.column?.contextMenu(menu, this, this.column)
     }
+
+    static { this.define() }
 }

--- a/lib/komps/spreadsheet/header-cell.js
+++ b/lib/komps/spreadsheet/header-cell.js
@@ -11,7 +11,7 @@ import Input from '../input.js';
  */
 export default class HeaderCell extends Cell {
     static tagName = 'komp-spreadsheet-header-cell'
-    static { this.define() }
+
     render () {
         content(this, result(this.column, 'header', this))
         return this
@@ -53,4 +53,6 @@ export default class HeaderCell extends Cell {
             this.table.unobserveResize(this)
         }
     }
+
+    static { this.define() }
 }

--- a/lib/komps/table.js
+++ b/lib/komps/table.js
@@ -50,7 +50,6 @@ export default class Table extends KompElement {
     }
     
     static tagName = 'komp-table'
-    static { this.define() }
     static columnTypeRegistry = {
         default: TableColumn
     }
@@ -653,4 +652,6 @@ export default class Table extends KompElement {
         ${this.tagName}-header-cell.frozen { z-index: 115; }
         ${this.tagName}-frozen-divider     { z-index: 120; }
     `}
+
+    static { this.define() }
 }

--- a/lib/komps/table/cell.js
+++ b/lib/komps/table/cell.js
@@ -27,7 +27,7 @@ import KompElement from '../element.js';
 
 export default class TableCell extends KompElement {
     static tagName = 'komp-table-cell'
-    static { this.define() }
+
     static assignableAttributes = {
         record: { type: ['object', 'function'], default: null, null: true },
         column: { type: 'object', default: null, null: true },
@@ -77,4 +77,6 @@ export default class TableCell extends KompElement {
     disconnected () {
         this.column.cells.delete(this)
     }
+
+    static { this.define() }
 }

--- a/lib/komps/table/group.js
+++ b/lib/komps/table/group.js
@@ -4,17 +4,18 @@ import KompElement from '../element.js';
 
 export default class TableGroup extends KompElement {
     static tagName = 'komp-table-group'
-    static { this.define() }
 
     get table () { return this.row?.table }
     get row () { return this.parentElement }
     get rowIndex () { return this.row.rowIndex }
-    
+
     get cells () { return Array.from(this.querySelectorAll(this.table.cellSelector))}
     get rowCount () { return Math.max(...this.cells.map(x => x.groupIndex)) }
-    
+
     append (...els) {
         const result = super.append(...els)
         return result
     }
+
+    static { this.define() }
 }

--- a/lib/komps/table/header-cell.js
+++ b/lib/komps/table/header-cell.js
@@ -5,12 +5,12 @@ import Cell from './cell.js';
 
 export default class HeaderCell extends Cell {
     static tagName = 'komp-table-header-cell'
-    static { this.define() }
+
     render () {
         content(this, result(this.column, 'header', this))
         return this
     }
-    
+
     connected () {
         super.connected()
         this.setAttribute('role', 'columnheader');
@@ -18,10 +18,12 @@ export default class HeaderCell extends Cell {
             this.table.observeResize(this)
         }
     }
-    
+
     disconnected () {
         if (this.column.frozen) {
             this.table.unobserveResize(this)
         }
     }
+
+    static { this.define() }
 }

--- a/lib/komps/table/header.js
+++ b/lib/komps/table/header.js
@@ -2,7 +2,6 @@ import TableRow from './row.js';
 
 export default class TableHeader extends TableRow {
     static tagName = 'komp-table-header'
-    static { this.define() }
 
     connected () {
         super.connected();
@@ -12,4 +11,6 @@ export default class TableHeader extends TableRow {
     rowIndexChanged(was, now) {
         this.style.gridRow = now
     }
+
+    static { this.define() }
 }

--- a/lib/komps/table/plugins/collapsible.js
+++ b/lib/komps/table/plugins/collapsible.js
@@ -24,7 +24,6 @@ import KompElement from '../../element.js';
 
 class TableToggle extends KompElement {
     static tagName = 'komp-table-toggle'
-    static { this.define() }
     static assignableAttributes = {
         column: { type: 'object', default: null, null: true },
         cellIndex: { type: 'number', default: null, null: true }
@@ -38,6 +37,8 @@ class TableToggle extends KompElement {
     disconnected () {
         this.column.toggles.delete(this)
     }
+
+    static { this.define() }
 }
 
 export default function (proto) {

--- a/lib/komps/table/row.js
+++ b/lib/komps/table/row.js
@@ -10,7 +10,6 @@ import { result } from '../../support.js';
  */
 export default class TableRow extends KompElement {
     static tagName = 'komp-table-row'
-    static { this.define() }
 
     static assignableAttributes = {
         rowIndex: { type: 'number', default: null, null: true },
@@ -90,4 +89,6 @@ export default class TableRow extends KompElement {
             return cell
         }
     }
+
+    static { this.define() }
 }

--- a/lib/komps/tooltip.js
+++ b/lib/komps/tooltip.js
@@ -29,7 +29,6 @@ const ACTIVE_KEY = Symbol('kompTooltip');
 
 export default class Tooltip extends Floater {
     static tagName = 'komp-tooltip'
-    static { this.define() }
 
     static assignableAttributes = {
         autoPlacement: { type: 'boolean', default: false, null: false },
@@ -132,4 +131,5 @@ export default class Tooltip extends Floater {
         };
     }
 
+    static { this.define() }
 }


### PR DESCRIPTION
## Summary

Follow-up to #37. Even with the cache-invalidation fix in `scanPrototypesFor`, the **first** instance constructed by an upgrade-during-class-init still ends up with empty static metadata — the cache no longer poisons subsequent instances, but that one early instance is broken. This change eliminates the timing window entirely.

`customElements.define` synchronously upgrades any pre-existing matching elements in the DOM, which runs the constructor. The constructor reads `assignableAttributes`, `events`, `bindMethods`, etc., and several components also touch class-level singletons like `static observer = new ResizeObserver(...)`. Calling `define()` mid-class-body — as we did everywhere, right after `static tagName = ...` — let that upgrade fire before the rest of the static field initializers had run.

Move every `static { this.define() }` block to be the **last** static in its class so registration always happens after the class is fully initialized. Document the requirement on `KompElement.define`'s JSDoc and update the `FormField` example.

Verified with a smoke test: parsing `<komp-dropzone enabled>` into the DOM and *then* importing the module now correctly resolves all three keys of `assignableAttributes` (`enabled`, `dragHereOverlay`, `dragOverOverlay`) on the upgraded instance.

Drops a leftover empty `if (!window.customElements.get('komp-floater')) {}` block at the bottom of `floater.js` (looks like a leftover from a previous registration refactor).

## Test plan

- [x] `npm test` — 33 passing
- [x] `npm run docs` builds without warnings
- [x] Smoke test: HTML-first `<komp-dropzone>` resolves full `assignableAttributes` after import
- [ ] Existing demos render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)