### PR TITLE
Position floater via transform to skip layout on scroll (1.x)

### DIFF
--- a/lib/komps/floater.js
+++ b/lib/komps/floater.js
@@ -199,8 +199,9 @@ export default class Floater extends KompElement {
     }
     
     computePosition({x, y, placement, middlewareData, ...args}) {
-        this.style.left = `${x}px`;
-        this.style.top = `${y}px`;
+        this.style.left = '0';
+        this.style.top = '0';
+        this.style.transform = `translate(${x}px, ${y}px)`;
         this.classList.remove('-top', '-left', '-bottom', '-right')
         this.classList.add('-' + placement.split('-')[0]);
 


### PR DESCRIPTION
## Summary
- Backport of the floater positioning change to 1.x.
- Replace `style.left`/`style.top` updates in `Floater.computePosition` with `transform: translate(...)` (anchored at `top:0; left:0`).
- Floater repositions on every scroll/resize via floating-ui's autoUpdate; setting top/left forces layout each call. `transform` lets the browser composite the move and avoids layout/paint on the hot path.

## Test plan
- [ ] Tooltips and dropdowns still anchor correctly to their triggers
- [ ] Reposition under scroll/resize tracks the anchor without drift
- [ ] Arrow positioning still aligns with the anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)