### PR TITLE
Remove tooltip when its anchor is removed from the DOM (1.x)

### DIFF
--- a/lib/komps/floater.js
+++ b/lib/komps/floater.js
@@ -191,6 +191,9 @@ export default class Floater extends KompElement {
     }
     
     updatePosition () {
+        if (!this.anchor.isConnected) {
+            return this.hideNow()
+        }
         computePosition(this.anchor, this, {
             strategy: this.strategy,
             placement: this.placement,

--- a/lib/komps/tooltip.js
+++ b/lib/komps/tooltip.js
@@ -72,15 +72,6 @@ export default class Tooltip extends Floater {
                 return false
             }
         }
-        if (this.anchor instanceof HTMLElement) {
-            const observer = new MutationObserver(() => {
-                if (!this.anchor.isConnected) {
-                    this.hideNow();
-                }
-            });
-            observer.observe(this.anchor.getRootNode(), { childList: true, subtree: true });
-            this._cleanupCallbacks.push(() => observer.disconnect());
-        }
     }
     
     anchorChanged (was, now) {

--- a/lib/komps/tooltip.js
+++ b/lib/komps/tooltip.js
@@ -72,6 +72,15 @@ export default class Tooltip extends Floater {
                 return false
             }
         }
+        if (this.anchor instanceof HTMLElement) {
+            const observer = new MutationObserver(() => {
+                if (!this.anchor.isConnected) {
+                    this.hideNow();
+                }
+            });
+            observer.observe(this.anchor.getRootNode(), { childList: true, subtree: true });
+            this._cleanupCallbacks.push(() => observer.disconnect());
+        }
     }
     
     anchorChanged (was, now) {


### PR DESCRIPTION
## Summary
- Backport of #44 to the 1.x branch
- Adds a `MutationObserver` in `Tooltip.connected()` that watches the anchor's root for DOM changes and tears down the tooltip via `hideNow()` once the anchor is no longer connected
- Observer is registered through `_cleanupCallbacks` so it's automatically disconnected when the tooltip leaves the DOM

Closes #40

## Test plan
- [ ] Show a tooltip on an anchor, then remove the anchor (or an ancestor) from the DOM — tooltip hides/animates out
- [ ] Show and dismiss a tooltip normally (mouseleave) — no observer leaks
- [ ] Tooltip with coordinate-style anchor (non-HTMLElement) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)