### PR TITLE
Add Mosaic component

### DIFF
--- a/docs/demo/pages/mosaic.html
+++ b/docs/demo/pages/mosaic.html
@@ -1,0 +1,99 @@
+<!--
+title: Mosaic
+-->
+<style>
+    .demo-container {
+        position: relative;
+        border: 1px solid #e2e2ea;
+        border-radius: 0.5em;
+        background: white;
+        padding: 1em;
+    }
+    komp-mosaic {
+        gap: 8px;
+    }
+    komp-mosaic > .cell {
+        background: #ede8f5;
+        border-radius: 0.25em;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.25em;
+        color: #5e5ce6;
+        user-select: none;
+    }
+    .hint {
+        text-align: center;
+        padding: 0.5em;
+        font-size: 0.85em;
+        color: #888;
+    }
+    .controls {
+        display: flex;
+        gap: 1em;
+        justify-content: center;
+        align-items: center;
+        padding: 0.5em;
+        font-size: 0.9em;
+    }
+    .controls label { color: #555; }
+    .controls input[type=number] { inline-size: 4em; }
+</style>
+
+<p class="hint">Drag a cell's right edge to grow its column span. Drag the bottom edge to grow its row span. Drag the body of a cell to move it — collisions bump other cells down.</p>
+
+<div class="controls">
+    <label>columnCount <input id="cc" type="number" value="12" min="1" max="24"></label>
+    <label>rowHeight <input id="rh" type="number" value="" placeholder="auto" min="20" max="400"></label>
+</div>
+
+<div class="demo-container">
+    <komp-mosaic id="m" columnCount="12" resizable reorderable></komp-mosaic>
+</div>
+
+<p class="hint" id="last-event">&nbsp;</p>
+
+<script type="module">
+    import Mosaic from './lib/komps/mosaic.js';
+    import { createElement } from 'dolla';
+
+    const m = document.getElementById('m');
+
+    // Eight starter tiles. Each cell sets its own grid-area.
+    const cells = [
+        { area: '1 / 1 / 2 / 4',  label: '1' },
+        { area: '1 / 4 / 2 / 7',  label: '2' },
+        { area: '1 / 7 / 2 / 13', label: '3' },
+        { area: '2 / 1 / 3 / 7',  label: '4' },
+        { area: '2 / 7 / 3 / 13', label: '5' },
+        { area: '3 / 1 / 4 / 8',  label: '6' },
+        { area: '3 / 8 / 4 / 13', label: '7' },
+        { area: '4 / 1 / 5 / 13', label: '8' },
+    ];
+    for (const c of cells) {
+        m.append(createElement('div', {
+            class: 'cell',
+            style: { 'grid-area': c.area },
+            content: c.label
+        }));
+    }
+
+    const lastEvent = document.getElementById('last-event');
+    m.addEventListener('resize', e => {
+        const { axis, rect, cell } = e.detail;
+        lastEvent.textContent = `resize (${axis}) "${cell.textContent}" → ${rect.r1}/${rect.c1}/${rect.r2}/${rect.c2}`;
+    });
+    m.addEventListener('reorder', e => {
+        const { rect, cell } = e.detail;
+        lastEvent.textContent = `reorder "${cell.textContent}" → ${rect.r1}/${rect.c1}/${rect.r2}/${rect.c2}`;
+    });
+
+    document.getElementById('cc').addEventListener('input', e => {
+        const v = parseInt(e.target.value, 10);
+        if (!isNaN(v) && v > 0) m.columnCount = v;
+    });
+    document.getElementById('rh').addEventListener('input', e => {
+        const v = e.target.value === '' ? null : parseInt(e.target.value, 10);
+        m.rowHeight = v;
+    });
+</script>

--- a/docs/demo/pages/mosaic.html
+++ b/docs/demo/pages/mosaic.html
@@ -81,11 +81,19 @@ title: Mosaic
     const lastEvent = document.getElementById('last-event');
     m.addEventListener('resize', e => {
         const { axis, rect, cell } = e.detail;
-        lastEvent.textContent = `resize (${axis}) "${cell.textContent}" → ${rect.r1}/${rect.c1}/${rect.r2}/${rect.c2}`;
+        lastEvent.textContent = `resize (${axis}) "${cell.textContent}" → ${rect.rowStart}/${rect.colStart}/${rect.rowEnd}/${rect.colEnd}`;
     });
     m.addEventListener('reorder', e => {
         const { rect, cell } = e.detail;
-        lastEvent.textContent = `reorder "${cell.textContent}" → ${rect.r1}/${rect.c1}/${rect.r2}/${rect.c2}`;
+        lastEvent.textContent = `reorder "${cell.textContent}" → ${rect.rowStart}/${rect.colStart}/${rect.rowEnd}/${rect.colEnd}`;
+    });
+    // gridAreaChanged bubbles from each affected cell. Brief tint so you can
+    // see which cells were touched (including those bumped by the cascade).
+    m.addEventListener('gridAreaChanged', e => {
+        const cell = e.target;
+        cell.style.transition = 'background 600ms ease';
+        cell.style.background = '#d9d4f0';
+        setTimeout(() => { cell.style.background = ''; }, 600);
     });
 
     document.getElementById('cc').addEventListener('input', e => {

--- a/docs/demo/pages/mosaic.html
+++ b/docs/demo/pages/mosaic.html
@@ -80,12 +80,12 @@ title: Mosaic
 
     const lastEvent = document.getElementById('last-event');
     m.addEventListener('resize', e => {
-        const { axis, rect, cell } = e.detail;
-        lastEvent.textContent = `resize (${axis}) "${cell.textContent}" → ${rect.rowStart}/${rect.colStart}/${rect.rowEnd}/${rect.colEnd}`;
+        const { axis, gridArea, cell } = e.detail;
+        lastEvent.textContent = `resize (${axis}) "${cell.textContent}" → ${gridArea.rowStart}/${gridArea.colStart}/${gridArea.rowEnd}/${gridArea.colEnd}`;
     });
     m.addEventListener('reorder', e => {
-        const { rect, cell } = e.detail;
-        lastEvent.textContent = `reorder "${cell.textContent}" → ${rect.rowStart}/${rect.colStart}/${rect.rowEnd}/${rect.colEnd}`;
+        const { gridArea, cell } = e.detail;
+        lastEvent.textContent = `reorder "${cell.textContent}" → ${gridArea.rowStart}/${gridArea.colStart}/${gridArea.rowEnd}/${gridArea.colEnd}`;
     });
     // gridAreaChanged bubbles from each affected cell. Brief tint so you can
     // see which cells were touched (including those bumped by the cascade).

--- a/docs/images/icons/mosaic.svg
+++ b/docs/images/icons/mosaic.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+<rect x="3" y="3" width="7" height="10"/>
+<rect x="13" y="3" width="7" height="17"/>
+<rect x="23" y="3" width="7" height="4"/>
+
+<rect x="3" y="16" width="7" height="4"/>
+<rect x="23" y="10" width="7" height="10"/>
+
+<rect x="3" y="23" width="13" height="7"/>
+<rect x="19" y="23" width="12" height="7"/>
+</svg>

--- a/lib/komps.js
+++ b/lib/komps.js
@@ -15,3 +15,4 @@ export { default as Form } from './komps/form.js';
 export { default as Resizer } from './komps/resizer.js';
 export { default as SearchField } from './komps/search-field.js';
 export { default as Select } from './komps/select.js';
+export { default as Mosaic } from './komps/mosaic.js';

--- a/lib/komps/mosaic.js
+++ b/lib/komps/mosaic.js
@@ -20,6 +20,11 @@
  * @fires Mosaic#resize
  * @fires Mosaic#reorder
  *
+ * Each cell whose grid-area changes also gets a bubbling
+ * `gridAreaChanged` event with `event.detail = { rect, previousRect }`.
+ * Includes cells that moved only because they were bumped by the cascade.
+ * Fires once at the end of a resize/reorder, not on intermediate paints.
+ *
  * @example
  * new Mosaic({
  *     columnCount: 12,
@@ -155,22 +160,22 @@ export default class Mosaic extends KompElement {
         }
     }
 
-    /** Read a cell's grid placement as a `{r1,c1,r2,c2}` rect (grid line numbers). */
+    /** Read a cell's grid placement as a `{rowStart, colStart, rowEnd, colEnd}` rect (grid line numbers). */
     _rectOf (cell) {
         const cs = getComputedStyle(cell)
-        const r1 = parseLine(cs.gridRowStart, 0)
-        const c1 = parseLine(cs.gridColumnStart, 0)
-        const r2 = parseLine(cs.gridRowEnd, r1)
-        const c2 = parseLine(cs.gridColumnEnd, c1)
-        if ([r1, r2, c1, c2].some(n => isNaN(n))) return null
-        return { r1, c1, r2, c2 }
+        const rowStart = parseLine(cs.gridRowStart, 0)
+        const colStart = parseLine(cs.gridColumnStart, 0)
+        const rowEnd = parseLine(cs.gridRowEnd, rowStart)
+        const colEnd = parseLine(cs.gridColumnEnd, colStart)
+        if ([rowStart, rowEnd, colStart, colEnd].some(n => isNaN(n))) return null
+        return { rowStart, colStart, rowEnd, colEnd }
     }
 
     _setRect (cell, r) {
-        cell.style.gridRowStart = r.r1
-        cell.style.gridRowEnd = r.r2
-        cell.style.gridColumnStart = r.c1
-        cell.style.gridColumnEnd = r.c2
+        cell.style.gridRowStart = r.rowStart
+        cell.style.gridRowEnd = r.rowEnd
+        cell.style.gridColumnStart = r.colStart
+        cell.style.gridColumnEnd = r.colEnd
         this._positionCellHandles(cell)
     }
 
@@ -202,17 +207,17 @@ export default class Mosaic extends KompElement {
         // CSS (justify/align-self + negative margin) centers the hit area on
         // the cell boundary / gap.
         const slots = {
-            right:  { r1: r.r1,     r2: r.r2,     c1: r.c2 - 1, c2: r.c2 },
-            left:   { r1: r.r1,     r2: r.r2,     c1: r.c1,     c2: r.c1 + 1 },
-            bottom: { r1: r.r2 - 1, r2: r.r2,     c1: r.c1,     c2: r.c2 },
-            top:    { r1: r.r1,     r2: r.r1 + 1, c1: r.c1,     c2: r.c2 },
+            right:  { rowStart: r.rowStart,     rowEnd: r.rowEnd,         colStart: r.colEnd - 1, colEnd: r.colEnd },
+            left:   { rowStart: r.rowStart,     rowEnd: r.rowEnd,         colStart: r.colStart,   colEnd: r.colStart + 1 },
+            bottom: { rowStart: r.rowEnd - 1,   rowEnd: r.rowEnd,         colStart: r.colStart,   colEnd: r.colEnd },
+            top:    { rowStart: r.rowStart,     rowEnd: r.rowStart + 1,   colStart: r.colStart,   colEnd: r.colEnd },
         }
         for (const [edge, h] of Object.entries(cell._handles)) {
             const s = slots[edge]
-            h.style.gridRowStart = s.r1
-            h.style.gridRowEnd = s.r2
-            h.style.gridColumnStart = s.c1
-            h.style.gridColumnEnd = s.c2
+            h.style.gridRowStart = s.rowStart
+            h.style.gridRowEnd = s.rowEnd
+            h.style.gridColumnStart = s.colStart
+            h.style.gridColumnEnd = s.colEnd
         }
     }
 
@@ -233,7 +238,8 @@ export default class Mosaic extends KompElement {
     }
 
     _overlaps (a, b) {
-        return a.r1 < b.r2 && a.r2 > b.r1 && a.c1 < b.c2 && a.c2 > b.c1
+        return a.rowStart < b.rowEnd && a.rowEnd > b.rowStart &&
+               a.colStart < b.colEnd && a.colEnd > b.colStart
     }
 
     /**
@@ -251,12 +257,12 @@ export default class Mosaic extends KompElement {
             for (const [other, or] of rects) {
                 if (other === c) continue
                 if (!this._overlaps(cr, or)) continue
-                const bump = cr.r2 - or.r1
+                const bump = cr.rowEnd - or.rowStart
                 rects.set(other, {
-                    r1: or.r1 + bump,
-                    r2: or.r2 + bump,
-                    c1: or.c1,
-                    c2: or.c2
+                    rowStart: or.rowStart + bump,
+                    rowEnd: or.rowEnd + bump,
+                    colStart: or.colStart,
+                    colEnd: or.colEnd
                 })
                 queue.push(other)
             }
@@ -273,6 +279,28 @@ export default class Mosaic extends KompElement {
     }
 
     /**
+     * Compare current cell rects against `startRects` and dispatch a bubbling
+     * `gridAreaChanged` event on every cell whose rect differs.
+     * `event.detail = { rect, previousRect }`. Called once at the end of a
+     * resize or reorder — never on intermediate paints — so listeners can
+     * react without per-frame overhead.
+     */
+    _emitGridAreaChanges (startRects) {
+        for (const cell of this.cells) {
+            const previousRect = startRects.get(cell)
+            if (!previousRect) continue
+            const rect = this._rectOf(cell)
+            if (!rect) continue
+            if (rect.rowStart === previousRect.rowStart && rect.colStart === previousRect.colStart &&
+                rect.rowEnd === previousRect.rowEnd && rect.colEnd === previousRect.colEnd) continue
+            cell.dispatchEvent(new CustomEvent('gridAreaChanged', {
+                detail: { rect, previousRect },
+                bubbles: true
+            }))
+        }
+    }
+
+    /**
      * Cells abutting `cell` along `edge` whose perpendicular extent fits
      * inside the cell's. A split-resize moves these in lockstep with the
      * dragged edge — wider neighbors fall through to the collision cascade
@@ -285,10 +313,10 @@ export default class Mosaic extends KompElement {
             if (other === cell) continue
             let fits = false
             switch (edge) {
-                case 'right':  fits = or.c1 === ar.c2 && or.r1 >= ar.r1 && or.r2 <= ar.r2; break
-                case 'left':   fits = or.c2 === ar.c1 && or.r1 >= ar.r1 && or.r2 <= ar.r2; break
-                case 'bottom': fits = or.r1 === ar.r2 && or.c1 >= ar.c1 && or.c2 <= ar.c2; break
-                case 'top':    fits = or.r2 === ar.r1 && or.c1 >= ar.c1 && or.c2 <= ar.c2; break
+                case 'right':  fits = or.colStart === ar.colEnd   && or.rowStart >= ar.rowStart && or.rowEnd <= ar.rowEnd; break
+                case 'left':   fits = or.colEnd   === ar.colStart && or.rowStart >= ar.rowStart && or.rowEnd <= ar.rowEnd; break
+                case 'bottom': fits = or.rowStart === ar.rowEnd   && or.colStart >= ar.colStart && or.colEnd <= ar.colEnd; break
+                case 'top':    fits = or.rowEnd   === ar.rowStart && or.colStart >= ar.colStart && or.colEnd <= ar.colEnd; break
             }
             if (fits) ns.push(other)
         }
@@ -305,19 +333,19 @@ export default class Mosaic extends KompElement {
         const isVertical = edge === 'left' || edge === 'right'
         const isEnd = edge === 'right' || edge === 'bottom'
         // Which line of the cell moves, and which line of each neighbor mirrors it.
-        // right:  cell.c2 ↔ neighbor.c1   left:  cell.c1 ↔ neighbor.c2
-        // bottom: cell.r2 ↔ neighbor.r1   top:   cell.r1 ↔ neighbor.r2
-        const cellKey = isVertical ? (isEnd ? 'c2' : 'c1') : (isEnd ? 'r2' : 'r1')
-        const neighborKey = isVertical ? (isEnd ? 'c1' : 'c2') : (isEnd ? 'r1' : 'r2')
-        const startKey = isVertical ? 'c1' : 'r1'
-        const endKey = isVertical ? 'c2' : 'r2'
+        // right:  cell.colEnd ↔ neighbor.colStart   left:  cell.colStart ↔ neighbor.colEnd
+        // bottom: cell.rowEnd ↔ neighbor.rowStart   top:   cell.rowStart ↔ neighbor.rowEnd
+        const cellKey = isVertical ? (isEnd ? 'colEnd' : 'colStart') : (isEnd ? 'rowEnd' : 'rowStart')
+        const neighborKey = isVertical ? (isEnd ? 'colStart' : 'colEnd') : (isEnd ? 'rowStart' : 'rowEnd')
+        const startKey = isVertical ? 'colStart' : 'rowStart'
+        const endKey = isVertical ? 'colEnd' : 'rowEnd'
 
         const startRect = this._rectOf(cell)
         if (!startRect) return
 
         const cellBR = cell.getBoundingClientRect()
-        const colPx = cellBR.width / (startRect.c2 - startRect.c1)
-        const rowPx = cellBR.height / (startRect.r2 - startRect.r1)
+        const colPx = cellBR.width / (startRect.colEnd - startRect.colStart)
+        const rowPx = cellBR.height / (startRect.rowEnd - startRect.rowStart)
         const startX = e.clientX
         const startY = e.clientY
 
@@ -328,7 +356,7 @@ export default class Mosaic extends KompElement {
         // cascade picks them up and bumps them instead.
         const neighbors = this._edgeNeighbors(cell, startRects, edge).filter(n => {
             const nr = startRects.get(n)
-            return (isVertical ? nr.c2 - nr.c1 : nr.r2 - nr.r1) > 1
+            return (isVertical ? nr.colEnd - nr.colStart : nr.rowEnd - nr.rowStart) > 1
         })
 
         // Clamp the drag so neither the dragged cell nor any neighbor falls
@@ -343,7 +371,7 @@ export default class Mosaic extends KompElement {
                     const nr = startRects.get(n)
                     return nr[endKey] - 1 - nr[neighborKey]
                 }))
-                : (isVertical ? this.columnCount + 1 - startRect.c2 : Infinity)
+                : (isVertical ? this.columnCount + 1 - startRect.colEnd : Infinity)
         } else {
             maxDelta = startRect[endKey] - 1 - startRect[cellKey]
             minDelta = neighbors.length
@@ -381,6 +409,7 @@ export default class Mosaic extends KompElement {
             window.removeEventListener('pointermove', move)
             handle.classList.remove('active')
             this.releasePointerCapture(e.pointerId)
+            this._emitGridAreaChanges(startRects)
             const finalRect = this._rectOf(cell)
             if (finalRect && finalRect[cellKey] !== startRect[cellKey]) {
                 this.trigger('resize', { detail: {
@@ -403,8 +432,8 @@ export default class Mosaic extends KompElement {
 
         const startRect = this._rectOf(cell)
         if (!startRect) return
-        const colSpan = startRect.c2 - startRect.c1
-        const rowSpan = startRect.r2 - startRect.r1
+        const colSpan = startRect.colEnd - startRect.colStart
+        const rowSpan = startRect.rowEnd - startRect.rowStart
 
         const cellBR = cell.getBoundingClientRect()
         const myBR = this.getBoundingClientRect()
@@ -437,11 +466,11 @@ export default class Mosaic extends KompElement {
             // preserving the cursor's grab offset.
             const targetX = ev.clientX - myBR.left - grabX
             const targetY = ev.clientY - myBR.top - grabY
-            let c1 = Math.round(targetX / colPx) + 1
-            let r1 = Math.round(targetY / rowPx) + 1
-            c1 = Math.max(1, Math.min(this.columnCount + 1 - colSpan, c1))
-            r1 = Math.max(1, r1)
-            const newRect = { r1, c1, r2: r1 + rowSpan, c2: c1 + colSpan }
+            let colStart = Math.round(targetX / colPx) + 1
+            let rowStart = Math.round(targetY / rowPx) + 1
+            colStart = Math.max(1, Math.min(this.columnCount + 1 - colSpan, colStart))
+            rowStart = Math.max(1, rowStart)
+            const newRect = { rowStart, colStart, rowEnd: rowStart + rowSpan, colEnd: colStart + colSpan }
 
             for (const [c, r] of startRects) working.set(c, { ...r })
             this._resolveCollisions(cell, newRect, working)
@@ -458,8 +487,9 @@ export default class Mosaic extends KompElement {
         }
         const up = () => {
             teardown()
+            this._emitGridAreaChanges(startRects)
             const finalRect = this._rectOf(cell)
-            if (finalRect && (finalRect.r1 !== startRect.r1 || finalRect.c1 !== startRect.c1)) {
+            if (finalRect && (finalRect.rowStart !== startRect.rowStart || finalRect.colStart !== startRect.colStart)) {
                 this.trigger('reorder', { detail: { cell, rect: finalRect } })
             }
         }

--- a/lib/komps/mosaic.js
+++ b/lib/komps/mosaic.js
@@ -1,0 +1,563 @@
+/**
+ * A managed CSS-Grid container. The mosaic sizes the grid
+ * (`columnCount` × `rowHeight`); each child cell declares its own
+ * `grid-area`. When `resizable` or `reorderable` is on, drag interactions
+ * update the affected cell's `grid-area` in place and run a "bump down"
+ * pass: any cell that would overlap the moved/resized cell is shifted
+ * down by enough rows to clear, cascading as needed.
+ *
+ * @class Mosaic
+ * @extends KompElement
+ *
+ * @param {Object} [options={}]
+ * @param {number} [options.columnCount=12] - Number of grid columns.
+ * @param {number} [options.rowHeight] - Row height in pixels. Defaults to `offsetWidth / columnCount` (square cells), tracked via ResizeObserver.
+ * @param {boolean} [options.resizable=false] - Render per-cell drag handles for live resizing.
+ * @param {boolean} [options.reorderable=false] - Drag a cell to reposition it on the grid; cells in the way bump down.
+ * @param {string} [options.handleSelector] - When set, only `pointerdown` on a matching descendant of a cell starts a reorder. Has no effect when `reorderable` is false.
+ * @param {string|HTMLElement|Array|Object} [options.content] - Initial children. Each must declare its own `grid-area`.
+ *
+ * @fires Mosaic#resize
+ * @fires Mosaic#reorder
+ *
+ * @example
+ * new Mosaic({
+ *     columnCount: 12,
+ *     rowHeight: 100,
+ *     resizable: true,
+ *     reorderable: true,
+ *     content: items.map((item, i) => createElement('div', {
+ *         style: { gridArea: `${i + 1} / 1 / span 1 / span 4` },
+ *         content: item.label
+ *     }))
+ * })
+ */
+
+/**
+ * Fired after a resize. `event.detail` is `{ cell, axis, edge, rect }`.
+ * @event Mosaic#resize
+ */
+
+/**
+ * Fired after a reorder. `event.detail` is `{ cell, rect }`.
+ * @event Mosaic#reorder
+ */
+
+import { createElement } from 'dolla';
+import KompElement from './element.js';
+
+// Resolve a grid-line computed value to an absolute line number.
+// Handles "auto", "span N", and explicit "N". `start` is the resolved
+// start-line of the same axis (used to expand "span N" into N + start).
+function parseLine (val, start) {
+    if (typeof val !== 'string' || val === 'auto') return NaN
+    if (val.startsWith('span ')) return start + parseInt(val.slice(5), 10)
+    return parseInt(val, 10)
+}
+
+export default class Mosaic extends KompElement {
+    static tagName = 'komp-mosaic'
+
+    static assignableAttributes = {
+        columnCount: { type: 'number', default: 12, null: false },
+        rowHeight: { type: 'number', default: null, null: true },
+        resizable: { type: 'boolean', default: false, null: false },
+        reorderable: { type: 'boolean', default: false, null: false },
+        handleSelector: { type: 'string', default: null, null: true }
+    }
+
+    static watch = ['columnCount', 'rowHeight', 'resizable', 'reorderable']
+    static events = ['resize', 'reorder']
+    static bindMethods = ['_onPointerDown', '_onMutation', '_onContainerResize']
+
+    initialize () {
+        super.initialize()
+        this._mutationObserver = new MutationObserver(this._onMutation)
+        this._resizeObserver = new ResizeObserver(this._onContainerResize)
+        this.addEventListener('pointerdown', this._onPointerDown)
+
+        // Snapshot the current row/column gap so handles can offset their
+        // negative margin into the gap center via CSS vars (no per-handle JS
+        // math). One-shot — may go stale if `gap` changes after mount.
+        const computed = getComputedStyle(this)
+        const shorthand = (computed.gap || '').split(/\s+/).filter(Boolean)
+        const rowGap = computed.rowGap || shorthand[0] || '0px'
+        const colGap = computed.columnGap || shorthand[1] || shorthand[0] || '0px'
+        this.style.setProperty('--komp-mosaic-column-gap', colGap)
+        this.style.setProperty('--komp-mosaic-row-gap', rowGap)
+    }
+
+    connected () {
+        this._mutationObserver?.observe(this, { childList: true })
+        this._resizeObserver?.observe(this)
+        this._applyGridTemplate()
+        if (this.resizable) {
+            for (const cell of this.cells) this._ensureCellHandles(cell)
+        }
+    }
+
+    disconnected () {
+        this._mutationObserver?.disconnect()
+        this._resizeObserver?.disconnect()
+    }
+
+    columnCountChanged () {
+        this._applyGridTemplate()
+    }
+    rowHeightChanged () {
+        this._applyGridTemplate()
+    }
+    resizableChanged () {
+        for (const cell of this.cells) {
+            if (this.resizable) this._ensureCellHandles(cell)
+            else this._removeCellHandles(cell)
+        }
+    }
+
+    /** Direct children that aren't internal handle or drag-clone elements. */
+    get cells () {
+        return this.querySelectorAll(':scope > *:not(komp-mosaic-handle):not(.komp-mosaic-drag-clone)')
+    }
+
+    _isCell (node) {
+        return node.localName !== 'komp-mosaic-handle' &&
+               !node.classList.contains('komp-mosaic-drag-clone')
+    }
+
+    _onContainerResize () {
+        // Recompute only when rowHeight is implicit (offsetWidth-driven).
+        if (this.rowHeight == null) this._applyGridTemplate()
+    }
+
+    _onMutation (mutations) {
+        for (const m of mutations) {
+            for (const node of m.addedNodes) {
+                if (node.nodeType === 1 && this._isCell(node) && this.resizable) {
+                    this._ensureCellHandles(node)
+                }
+            }
+            for (const node of m.removedNodes) {
+                if (node.nodeType === 1 && this._isCell(node)) {
+                    this._removeCellHandles(node)
+                }
+            }
+        }
+    }
+
+    _applyGridTemplate () {
+        const cols = this.columnCount
+        const h = this.rowHeight ?? (this.offsetWidth / cols)
+        this.style.gridTemplateColumns = `repeat(${cols}, 1fr)`
+        this.style.gridAutoRows = `${h}px`
+        // Cell pixel sizes may have changed; reposition handles.
+        if (this.resizable) {
+            for (const cell of this.cells) this._positionCellHandles(cell)
+        }
+    }
+
+    /** Read a cell's grid placement as a `{r1,c1,r2,c2}` rect (grid line numbers). */
+    _rectOf (cell) {
+        const cs = getComputedStyle(cell)
+        const r1 = parseLine(cs.gridRowStart, 0)
+        const c1 = parseLine(cs.gridColumnStart, 0)
+        const r2 = parseLine(cs.gridRowEnd, r1)
+        const c2 = parseLine(cs.gridColumnEnd, c1)
+        if ([r1, r2, c1, c2].some(n => isNaN(n))) return null
+        return { r1, c1, r2, c2 }
+    }
+
+    _setRect (cell, r) {
+        cell.style.gridRowStart = r.r1
+        cell.style.gridRowEnd = r.r2
+        cell.style.gridColumnStart = r.c1
+        cell.style.gridColumnEnd = r.c2
+        this._positionCellHandles(cell)
+    }
+
+    _ensureCellHandles (cell) {
+        cell._handles ??= {}
+        for (const edge of ['top', 'right', 'bottom', 'left']) {
+            if (cell._handles[edge]) continue
+            const axis = (edge === 'left' || edge === 'right') ? 'vertical' : 'horizontal'
+            const h = createElement('komp-mosaic-handle', {
+                class: axis,
+                data: { edge }
+            })
+            h.cell = cell
+            cell._handles[edge] = h
+            this.appendChild(h)
+        }
+        this._positionCellHandles(cell)
+    }
+
+    _removeCellHandles (cell) {
+        for (const h of Object.values(cell._handles || {})) h.remove()
+        delete cell._handles
+    }
+
+    _positionCellHandles (cell) {
+        const r = this._rectOf(cell)
+        if (!r || !cell._handles) return
+        // Each handle occupies a 1-track-thick grid area pinned to its edge.
+        // CSS (justify/align-self + negative margin) centers the hit area on
+        // the cell boundary / gap.
+        const slots = {
+            right:  { r1: r.r1,     r2: r.r2,     c1: r.c2 - 1, c2: r.c2 },
+            left:   { r1: r.r1,     r2: r.r2,     c1: r.c1,     c2: r.c1 + 1 },
+            bottom: { r1: r.r2 - 1, r2: r.r2,     c1: r.c1,     c2: r.c2 },
+            top:    { r1: r.r1,     r2: r.r1 + 1, c1: r.c1,     c2: r.c2 },
+        }
+        for (const [edge, h] of Object.entries(cell._handles)) {
+            const s = slots[edge]
+            h.style.gridRowStart = s.r1
+            h.style.gridRowEnd = s.r2
+            h.style.gridColumnStart = s.c1
+            h.style.gridColumnEnd = s.c2
+        }
+    }
+
+    _onPointerDown (e) {
+        const handle = e.target.closest('komp-mosaic-handle')
+        if (handle && this.resizable) {
+            this._startResize(e, handle)
+            return
+        }
+        if (this.reorderable) {
+            if (this.handleSelector) {
+                const grip = e.target.closest(this.handleSelector)
+                if (!grip || !this.contains(grip)) return
+            }
+            const cell = e.target.closest(`${this.localName} > *`)
+            if (cell && this._isCell(cell)) this._startReorder(e, cell)
+        }
+    }
+
+    _overlaps (a, b) {
+        return a.r1 < b.r2 && a.r2 > b.r1 && a.c1 < b.c2 && a.c2 > b.c1
+    }
+
+    /**
+     * Apply `newRect` to `movedCell` inside `rects` and bump any cells it
+     * collides with downward by enough rows to clear. Bumps cascade: a
+     * bumped cell that now overlaps another also pushes it down. Columns
+     * are preserved — only row lines move.
+     */
+    _resolveCollisions (movedCell, newRect, rects) {
+        rects.set(movedCell, newRect)
+        const queue = [movedCell]
+        while (queue.length) {
+            const c = queue.shift()
+            const cr = rects.get(c)
+            for (const [other, or] of rects) {
+                if (other === c) continue
+                if (!this._overlaps(cr, or)) continue
+                const bump = cr.r2 - or.r1
+                rects.set(other, {
+                    r1: or.r1 + bump,
+                    r2: or.r2 + bump,
+                    c1: or.c1,
+                    c2: or.c2
+                })
+                queue.push(other)
+            }
+        }
+    }
+
+    _snapshotRects () {
+        const rects = new Map()
+        for (const c of this.cells) {
+            const r = this._rectOf(c)
+            if (r) rects.set(c, r)
+        }
+        return rects
+    }
+
+    /**
+     * Cells abutting `cell` along `edge` whose perpendicular extent fits
+     * inside the cell's. A split-resize moves these in lockstep with the
+     * dragged edge — wider neighbors fall through to the collision cascade
+     * so they're bumped instead of clamping the drag to zero.
+     */
+    _edgeNeighbors (cell, rects, edge) {
+        const ar = rects.get(cell)
+        const ns = []
+        for (const [other, or] of rects) {
+            if (other === cell) continue
+            let fits = false
+            switch (edge) {
+                case 'right':  fits = or.c1 === ar.c2 && or.r1 >= ar.r1 && or.r2 <= ar.r2; break
+                case 'left':   fits = or.c2 === ar.c1 && or.r1 >= ar.r1 && or.r2 <= ar.r2; break
+                case 'bottom': fits = or.r1 === ar.r2 && or.c1 >= ar.c1 && or.c2 <= ar.c2; break
+                case 'top':    fits = or.r2 === ar.r1 && or.c1 >= ar.c1 && or.c2 <= ar.c2; break
+            }
+            if (fits) ns.push(other)
+        }
+        return ns
+    }
+
+    _startResize (e, handle) {
+        e.preventDefault()
+        this.setPointerCapture(e.pointerId)
+        handle.classList.add('active')
+
+        const cell = handle.cell
+        const edge = handle.dataset.edge
+        const isVertical = edge === 'left' || edge === 'right'
+        const isEnd = edge === 'right' || edge === 'bottom'
+        // Which line of the cell moves, and which line of each neighbor mirrors it.
+        // right:  cell.c2 ↔ neighbor.c1   left:  cell.c1 ↔ neighbor.c2
+        // bottom: cell.r2 ↔ neighbor.r1   top:   cell.r1 ↔ neighbor.r2
+        const cellKey = isVertical ? (isEnd ? 'c2' : 'c1') : (isEnd ? 'r2' : 'r1')
+        const neighborKey = isVertical ? (isEnd ? 'c1' : 'c2') : (isEnd ? 'r1' : 'r2')
+        const startKey = isVertical ? 'c1' : 'r1'
+        const endKey = isVertical ? 'c2' : 'r2'
+
+        const startRect = this._rectOf(cell)
+        if (!startRect) return
+
+        const cellBR = cell.getBoundingClientRect()
+        const colPx = cellBR.width / (startRect.c2 - startRect.c1)
+        const rowPx = cellBR.height / (startRect.r2 - startRect.r1)
+        const startX = e.clientX
+        const startY = e.clientY
+
+        const startRects = this._snapshotRects()
+        const working = new Map(startRects)
+        // Neighbors at minimum size on the resize axis can't shrink any
+        // further — exclude them so the boundary isn't frozen. The collision
+        // cascade picks them up and bumps them instead.
+        const neighbors = this._edgeNeighbors(cell, startRects, edge).filter(n => {
+            const nr = startRects.get(n)
+            return (isVertical ? nr.c2 - nr.c1 : nr.r2 - nr.r1) > 1
+        })
+
+        // Clamp the drag so neither the dragged cell nor any neighbor falls
+        // below 1 unit on the resize axis. The cell shrinks when its dragged
+        // edge moves inward; each neighbor shrinks when its mirror edge moves
+        // outward (toward its own far edge).
+        let minDelta, maxDelta
+        if (isEnd) {
+            minDelta = startRect[startKey] + 1 - startRect[cellKey]
+            maxDelta = neighbors.length
+                ? Math.min(...neighbors.map(n => {
+                    const nr = startRects.get(n)
+                    return nr[endKey] - 1 - nr[neighborKey]
+                }))
+                : (isVertical ? this.columnCount + 1 - startRect.c2 : Infinity)
+        } else {
+            maxDelta = startRect[endKey] - 1 - startRect[cellKey]
+            minDelta = neighbors.length
+                ? Math.max(...neighbors.map(n => {
+                    const nr = startRects.get(n)
+                    return nr[startKey] + 1 - nr[neighborKey]
+                }))
+                : (1 - startRect[cellKey])
+        }
+
+        const move = (ev) => {
+            const raw = isVertical
+                ? Math.round((ev.clientX - startX) / colPx)
+                : Math.round((ev.clientY - startY) / rowPx)
+            const delta = Math.max(minDelta, Math.min(maxDelta, raw))
+
+            // Reset every frame so deltas apply to the start state, not the
+            // accumulating intermediate one.
+            for (const [c, r] of startRects) working.set(c, { ...r })
+
+            // Shift each neighbor's mirror line by `delta` so the boundary
+            // moves in lockstep with the cell's edge.
+            for (const n of neighbors) {
+                const ns = startRects.get(n)
+                working.set(n, { ...ns, [neighborKey]: ns[neighborKey] + delta })
+            }
+
+            const newRect = { ...startRect, [cellKey]: startRect[cellKey] + delta }
+
+            // Run the cascade in case the cell grew into a non-adjacent cell.
+            this._resolveCollisions(cell, newRect, working)
+            for (const [c, r] of working) this._setRect(c, r)
+        }
+        const up = () => {
+            window.removeEventListener('pointermove', move)
+            handle.classList.remove('active')
+            this.releasePointerCapture(e.pointerId)
+            const finalRect = this._rectOf(cell)
+            if (finalRect && finalRect[cellKey] !== startRect[cellKey]) {
+                this.trigger('resize', { detail: {
+                    axis: isVertical ? 'column' : 'row',
+                    edge,
+                    cell,
+                    rect: finalRect
+                }})
+            }
+        }
+        window.addEventListener('pointermove', move)
+        window.addEventListener('pointerup', up, { once: true })
+    }
+
+    _startReorder (e, cell) {
+        e.preventDefault()
+        this.setPointerCapture(e.pointerId)
+        this.classList.add('reordering')
+        cell.classList.add('dragging')
+
+        const startRect = this._rectOf(cell)
+        if (!startRect) return
+        const colSpan = startRect.c2 - startRect.c1
+        const rowSpan = startRect.r2 - startRect.r1
+
+        const cellBR = cell.getBoundingClientRect()
+        const myBR = this.getBoundingClientRect()
+        const colPx = myBR.width / this.columnCount
+        const rowPx = cellBR.height / rowSpan
+
+        const grabX = e.clientX - cellBR.left
+        const grabY = e.clientY - cellBR.top
+
+        const startRects = this._snapshotRects()
+        const working = new Map(startRects)
+
+        const clone = cell.cloneNode(true)
+        clone.classList.add('komp-mosaic-drag-clone')
+        clone.style.position = 'fixed'
+        clone.style.top = '0'
+        clone.style.left = '0'
+        clone.style.width = cellBR.width + 'px'
+        clone.style.height = cellBR.height + 'px'
+        clone.style.margin = '0'
+        clone.style.transform = `translate(${cellBR.left}px, ${cellBR.top}px)`
+        clone.style.gridColumn = '1'
+        clone.style.gridRow = '1'
+        this.prepend(clone)
+
+        const move = (ev) => {
+            clone.style.transform = `translate(${ev.clientX - grabX}px, ${ev.clientY - grabY}px)`
+
+            // Snap the cell's top-left to the nearest grid line under the cursor,
+            // preserving the cursor's grab offset.
+            const targetX = ev.clientX - myBR.left - grabX
+            const targetY = ev.clientY - myBR.top - grabY
+            let c1 = Math.round(targetX / colPx) + 1
+            let r1 = Math.round(targetY / rowPx) + 1
+            c1 = Math.max(1, Math.min(this.columnCount + 1 - colSpan, c1))
+            r1 = Math.max(1, r1)
+            const newRect = { r1, c1, r2: r1 + rowSpan, c2: c1 + colSpan }
+
+            for (const [c, r] of startRects) working.set(c, { ...r })
+            this._resolveCollisions(cell, newRect, working)
+            for (const [c, r] of working) this._setRect(c, r)
+        }
+        const teardown = () => {
+            window.removeEventListener('pointermove', move)
+            window.removeEventListener('pointerup', up)
+            window.removeEventListener('keydown', keydown)
+            clone.remove()
+            cell.classList.remove('dragging')
+            this.classList.remove('reordering')
+            try { this.releasePointerCapture(e.pointerId) } catch {}
+        }
+        const up = () => {
+            teardown()
+            const finalRect = this._rectOf(cell)
+            if (finalRect && (finalRect.r1 !== startRect.r1 || finalRect.c1 !== startRect.c1)) {
+                this.trigger('reorder', { detail: { cell, rect: finalRect } })
+            }
+        }
+        const keydown = (ev) => {
+            if (ev.key !== 'Escape') return
+            for (const [c, r] of startRects) this._setRect(c, r)
+            teardown()
+        }
+        window.addEventListener('pointermove', move)
+        window.addEventListener('pointerup', up)
+        window.addEventListener('keydown', keydown)
+    }
+
+    static style = `
+        komp-mosaic {
+            display: grid;
+            position: relative;
+        }
+        komp-mosaic.reordering {
+            cursor: grabbing;
+        }
+        komp-mosaic-handle {
+            position: relative;
+            z-index: 5;
+            background: transparent;
+            touch-action: none;
+        }
+        /* Where a left/top handle shares a boundary with another cell's
+           right/bottom handle, the right/bottom one wins the click — its
+           cell can grow into the boundary; the opposing cell would need to
+           shrink (often impossible for 1-track cells). */
+        komp-mosaic-handle[data-edge="right"],
+        komp-mosaic-handle[data-edge="bottom"] {
+            z-index: 6;
+        }
+        komp-mosaic-handle.vertical {
+            cursor: col-resize;
+            align-self: stretch;
+            inline-size: 16px;
+        }
+        komp-mosaic-handle.vertical[data-edge="right"] {
+            justify-self: end;
+            margin-inline-end: calc(-8px - var(--komp-mosaic-column-gap, 0px) / 2);
+        }
+        komp-mosaic-handle.vertical[data-edge="left"] {
+            justify-self: start;
+            margin-inline-start: calc(-8px - var(--komp-mosaic-column-gap, 0px) / 2);
+        }
+        komp-mosaic-handle.horizontal {
+            cursor: row-resize;
+            justify-self: stretch;
+            block-size: 16px;
+        }
+        komp-mosaic-handle.horizontal[data-edge="bottom"] {
+            align-self: end;
+            margin-block-end: calc(-8px - var(--komp-mosaic-row-gap, 0px) / 2);
+        }
+        komp-mosaic-handle.horizontal[data-edge="top"] {
+            align-self: start;
+            margin-block-start: calc(-8px - var(--komp-mosaic-row-gap, 0px) / 2);
+        }
+        komp-mosaic-handle::after {
+            content: '';
+            position: absolute;
+            pointer-events: none;
+            background: transparent;
+            transition: background 100ms ease;
+        }
+        komp-mosaic-handle.vertical::after {
+            inset-block: 0;
+            inset-inline-start: 7px;
+            inline-size: 2px;
+        }
+        komp-mosaic-handle.horizontal::after {
+            inset-inline: 0;
+            inset-block-start: 7px;
+            block-size: 2px;
+        }
+        komp-mosaic-handle:hover::after {
+            background: rgba(0, 0, 255, 0.5);
+        }
+        komp-mosaic-handle.active::after {
+            background: rgba(0, 0, 255, 0.9);
+        }
+        komp-mosaic.reordering > *:not(komp-mosaic-handle):not(.komp-mosaic-drag-clone) {
+            pointer-events: none;
+        }
+        komp-mosaic > .dragging {
+            opacity: 0.3;
+            cursor: grabbing;
+        }
+        .komp-mosaic-drag-clone {
+            pointer-events: none;
+            opacity: 0.9;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+            z-index: 9999;
+            will-change: transform;
+        }
+    `
+    static { this.define() }
+}

--- a/lib/komps/mosaic.js
+++ b/lib/komps/mosaic.js
@@ -1,6 +1,6 @@
 /**
- * A managed CSS-Grid container. The mosaic sizes the grid
- * (`columnCount` × `rowHeight`); each child cell declares its own
+ * Mosiac is a managed CSS-Grid container that sizes to a grid
+ * (`columnCount` × `rowHeight`). Each child cell declares its own
  * `grid-area`. When `resizable` or `reorderable` is on, drag interactions
  * update the affected cell's `grid-area` in place and run a "bump down"
  * pass: any cell that would overlap the moved/resized cell is shifted
@@ -12,8 +12,8 @@
  * @param {Object} [options={}]
  * @param {number} [options.columnCount=12] - Number of grid columns.
  * @param {number} [options.rowHeight] - Row height in pixels. Defaults to `offsetWidth / columnCount` (square cells), tracked via ResizeObserver.
- * @param {boolean} [options.resizable=false] - Render per-cell drag handles for live resizing.
- * @param {boolean} [options.reorderable=false] - Drag a cell to reposition it on the grid; cells in the way bump down.
+ * @param {boolean} [options.resizable=true] - Render per-cell drag handles for live resizing.
+ * @param {boolean} [options.reorderable=true] - Drag a cell to reposition it on the grid; cells in the way bump down.
  * @param {string} [options.handleSelector] - When set, only `pointerdown` on a matching descendant of a cell starts a reorder. Has no effect when `reorderable` is false.
  * @param {string|HTMLElement|Array|Object} [options.content] - Initial children. Each must declare its own `grid-area`.
  *
@@ -21,7 +21,7 @@
  * @fires Mosaic#reorder
  *
  * Each cell whose grid-area changes also gets a bubbling
- * `gridAreaChanged` event with `event.detail = { rect, previousRect }`.
+ * `gridAreaChanged` event with `event.detail = { gridArea, previousGridArea }`.
  * Includes cells that moved only because they were bumped by the cascade.
  * Fires once at the end of a resize/reorder, not on intermediate paints.
  *
@@ -39,12 +39,12 @@
  */
 
 /**
- * Fired after a resize. `event.detail` is `{ cell, axis, edge, rect }`.
+ * Fired after a resize. `event.detail` is `{ cell, axis, edge, gridArea }`.
  * @event Mosaic#resize
  */
 
 /**
- * Fired after a reorder. `event.detail` is `{ cell, rect }`.
+ * Fired after a reorder. `event.detail` is `{ cell, gridArea }`.
  * @event Mosaic#reorder
  */
 
@@ -66,8 +66,8 @@ export default class Mosaic extends KompElement {
     static assignableAttributes = {
         columnCount: { type: 'number', default: 12, null: false },
         rowHeight: { type: 'number', default: null, null: true },
-        resizable: { type: 'boolean', default: false, null: false },
-        reorderable: { type: 'boolean', default: false, null: false },
+        resizable: { type: 'boolean', default: true, null: false },
+        reorderable: { type: 'boolean', default: true, null: false },
         handleSelector: { type: 'string', default: null, null: true }
     }
 
@@ -106,6 +106,7 @@ export default class Mosaic extends KompElement {
         this._resizeObserver?.disconnect()
     }
 
+    // Attribute Changes
     columnCountChanged () {
         this._applyGridTemplate()
     }
@@ -154,14 +155,10 @@ export default class Mosaic extends KompElement {
         const h = this.rowHeight ?? (this.offsetWidth / cols)
         this.style.gridTemplateColumns = `repeat(${cols}, 1fr)`
         this.style.gridAutoRows = `${h}px`
-        // Cell pixel sizes may have changed; reposition handles.
-        if (this.resizable) {
-            for (const cell of this.cells) this._positionCellHandles(cell)
-        }
     }
 
-    /** Read a cell's grid placement as a `{rowStart, colStart, rowEnd, colEnd}` rect (grid line numbers). */
-    _rectOf (cell) {
+    /** Read a cell's grid placement as a `{rowStart, colStart, rowEnd, colEnd}` object (grid line numbers). */
+    _getGridArea (cell) {
         const cs = getComputedStyle(cell)
         const rowStart = parseLine(cs.gridRowStart, 0)
         const colStart = parseLine(cs.gridColumnStart, 0)
@@ -171,11 +168,11 @@ export default class Mosaic extends KompElement {
         return { rowStart, colStart, rowEnd, colEnd }
     }
 
-    _setRect (cell, r) {
-        cell.style.gridRowStart = r.rowStart
-        cell.style.gridRowEnd = r.rowEnd
-        cell.style.gridColumnStart = r.colStart
-        cell.style.gridColumnEnd = r.colEnd
+    _setGridArea (cell, gridArea) {
+        cell.style.gridRowStart = gridArea.rowStart
+        cell.style.gridRowEnd = gridArea.rowEnd
+        cell.style.gridColumnStart = gridArea.colStart
+        cell.style.gridColumnEnd = gridArea.colEnd
         this._positionCellHandles(cell)
     }
 
@@ -201,16 +198,16 @@ export default class Mosaic extends KompElement {
     }
 
     _positionCellHandles (cell) {
-        const r = this._rectOf(cell)
-        if (!r || !cell._handles) return
+        const ga = this._getGridArea(cell)
+        if (!ga || !cell._handles) return
         // Each handle occupies a 1-track-thick grid area pinned to its edge.
         // CSS (justify/align-self + negative margin) centers the hit area on
         // the cell boundary / gap.
         const slots = {
-            right:  { rowStart: r.rowStart,     rowEnd: r.rowEnd,         colStart: r.colEnd - 1, colEnd: r.colEnd },
-            left:   { rowStart: r.rowStart,     rowEnd: r.rowEnd,         colStart: r.colStart,   colEnd: r.colStart + 1 },
-            bottom: { rowStart: r.rowEnd - 1,   rowEnd: r.rowEnd,         colStart: r.colStart,   colEnd: r.colEnd },
-            top:    { rowStart: r.rowStart,     rowEnd: r.rowStart + 1,   colStart: r.colStart,   colEnd: r.colEnd },
+            right:  { rowStart: ga.rowStart,     rowEnd: ga.rowEnd,         colStart: ga.colEnd - 1, colEnd: ga.colEnd },
+            left:   { rowStart: ga.rowStart,     rowEnd: ga.rowEnd,         colStart: ga.colStart,   colEnd: ga.colStart + 1 },
+            bottom: { rowStart: ga.rowEnd - 1,   rowEnd: ga.rowEnd,         colStart: ga.colStart,   colEnd: ga.colEnd },
+            top:    { rowStart: ga.rowStart,     rowEnd: ga.rowStart + 1,   colStart: ga.colStart,   colEnd: ga.colEnd },
         }
         for (const [edge, h] of Object.entries(cell._handles)) {
             const s = slots[edge]
@@ -243,58 +240,58 @@ export default class Mosaic extends KompElement {
     }
 
     /**
-     * Apply `newRect` to `movedCell` inside `rects` and bump any cells it
-     * collides with downward by enough rows to clear. Bumps cascade: a
+     * Apply `newGridArea` to `movedCell` inside `gridAreas` and bump any cells
+     * it collides with downward by enough rows to clear. Bumps cascade: a
      * bumped cell that now overlaps another also pushes it down. Columns
      * are preserved — only row lines move.
      */
-    _resolveCollisions (movedCell, newRect, rects) {
-        rects.set(movedCell, newRect)
+    _resolveCollisions (movedCell, newGridArea, gridAreas) {
+        gridAreas.set(movedCell, newGridArea)
         const queue = [movedCell]
         while (queue.length) {
             const c = queue.shift()
-            const cr = rects.get(c)
-            for (const [other, or] of rects) {
+            const cga = gridAreas.get(c)
+            for (const [other, oga] of gridAreas) {
                 if (other === c) continue
-                if (!this._overlaps(cr, or)) continue
-                const bump = cr.rowEnd - or.rowStart
-                rects.set(other, {
-                    rowStart: or.rowStart + bump,
-                    rowEnd: or.rowEnd + bump,
-                    colStart: or.colStart,
-                    colEnd: or.colEnd
+                if (!this._overlaps(cga, oga)) continue
+                const bump = cga.rowEnd - oga.rowStart
+                gridAreas.set(other, {
+                    rowStart: oga.rowStart + bump,
+                    rowEnd: oga.rowEnd + bump,
+                    colStart: oga.colStart,
+                    colEnd: oga.colEnd
                 })
                 queue.push(other)
             }
         }
     }
 
-    _snapshotRects () {
-        const rects = new Map()
+    _snapshotGridAreas () {
+        const map = new Map()
         for (const c of this.cells) {
-            const r = this._rectOf(c)
-            if (r) rects.set(c, r)
+            const ga = this._getGridArea(c)
+            if (ga) map.set(c, ga)
         }
-        return rects
+        return map
     }
 
     /**
-     * Compare current cell rects against `startRects` and dispatch a bubbling
-     * `gridAreaChanged` event on every cell whose rect differs.
-     * `event.detail = { rect, previousRect }`. Called once at the end of a
-     * resize or reorder — never on intermediate paints — so listeners can
+     * Compare current cell grid-areas against `startGridAreas` and dispatch a
+     * bubbling `gridAreaChanged` event on every cell whose grid-area differs.
+     * `event.detail = { gridArea, previousGridArea }`. Called once at the end
+     * of a resize or reorder — never on intermediate paints — so listeners can
      * react without per-frame overhead.
      */
-    _emitGridAreaChanges (startRects) {
+    _emitGridAreaChanges (startGridAreas) {
         for (const cell of this.cells) {
-            const previousRect = startRects.get(cell)
-            if (!previousRect) continue
-            const rect = this._rectOf(cell)
-            if (!rect) continue
-            if (rect.rowStart === previousRect.rowStart && rect.colStart === previousRect.colStart &&
-                rect.rowEnd === previousRect.rowEnd && rect.colEnd === previousRect.colEnd) continue
+            const previousGridArea = startGridAreas.get(cell)
+            if (!previousGridArea) continue
+            const gridArea = this._getGridArea(cell)
+            if (!gridArea) continue
+            if (gridArea.rowStart === previousGridArea.rowStart && gridArea.colStart === previousGridArea.colStart &&
+                gridArea.rowEnd === previousGridArea.rowEnd && gridArea.colEnd === previousGridArea.colEnd) continue
             cell.dispatchEvent(new CustomEvent('gridAreaChanged', {
-                detail: { rect, previousRect },
+                detail: { gridArea, previousGridArea },
                 bubbles: true
             }))
         }
@@ -306,17 +303,17 @@ export default class Mosaic extends KompElement {
      * dragged edge — wider neighbors fall through to the collision cascade
      * so they're bumped instead of clamping the drag to zero.
      */
-    _edgeNeighbors (cell, rects, edge) {
-        const ar = rects.get(cell)
+    _edgeNeighbors (cell, gridAreas, edge) {
+        const ga = gridAreas.get(cell)
         const ns = []
-        for (const [other, or] of rects) {
+        for (const [other, oga] of gridAreas) {
             if (other === cell) continue
             let fits = false
             switch (edge) {
-                case 'right':  fits = or.colStart === ar.colEnd   && or.rowStart >= ar.rowStart && or.rowEnd <= ar.rowEnd; break
-                case 'left':   fits = or.colEnd   === ar.colStart && or.rowStart >= ar.rowStart && or.rowEnd <= ar.rowEnd; break
-                case 'bottom': fits = or.rowStart === ar.rowEnd   && or.colStart >= ar.colStart && or.colEnd <= ar.colEnd; break
-                case 'top':    fits = or.rowEnd   === ar.rowStart && or.colStart >= ar.colStart && or.colEnd <= ar.colEnd; break
+                case 'right':  fits = oga.colStart === ga.colEnd   && oga.rowStart >= ga.rowStart && oga.rowEnd <= ga.rowEnd; break
+                case 'left':   fits = oga.colEnd   === ga.colStart && oga.rowStart >= ga.rowStart && oga.rowEnd <= ga.rowEnd; break
+                case 'bottom': fits = oga.rowStart === ga.rowEnd   && oga.colStart >= ga.colStart && oga.colEnd <= ga.colEnd; break
+                case 'top':    fits = oga.rowEnd   === ga.rowStart && oga.colStart >= ga.colStart && oga.colEnd <= ga.colEnd; break
             }
             if (fits) ns.push(other)
         }
@@ -340,23 +337,23 @@ export default class Mosaic extends KompElement {
         const startKey = isVertical ? 'colStart' : 'rowStart'
         const endKey = isVertical ? 'colEnd' : 'rowEnd'
 
-        const startRect = this._rectOf(cell)
-        if (!startRect) return
+        const startGridArea = this._getGridArea(cell)
+        if (!startGridArea) return
 
         const cellBR = cell.getBoundingClientRect()
-        const colPx = cellBR.width / (startRect.colEnd - startRect.colStart)
-        const rowPx = cellBR.height / (startRect.rowEnd - startRect.rowStart)
+        const colPx = cellBR.width / (startGridArea.colEnd - startGridArea.colStart)
+        const rowPx = cellBR.height / (startGridArea.rowEnd - startGridArea.rowStart)
         const startX = e.clientX
         const startY = e.clientY
 
-        const startRects = this._snapshotRects()
-        const working = new Map(startRects)
+        const startGridAreas = this._snapshotGridAreas()
+        const working = new Map(startGridAreas)
         // Neighbors at minimum size on the resize axis can't shrink any
         // further — exclude them so the boundary isn't frozen. The collision
         // cascade picks them up and bumps them instead.
-        const neighbors = this._edgeNeighbors(cell, startRects, edge).filter(n => {
-            const nr = startRects.get(n)
-            return (isVertical ? nr.colEnd - nr.colStart : nr.rowEnd - nr.rowStart) > 1
+        const neighbors = this._edgeNeighbors(cell, startGridAreas, edge).filter(n => {
+            const nga = startGridAreas.get(n)
+            return (isVertical ? nga.colEnd - nga.colStart : nga.rowEnd - nga.rowStart) > 1
         })
 
         // Clamp the drag so neither the dragged cell nor any neighbor falls
@@ -365,21 +362,21 @@ export default class Mosaic extends KompElement {
         // outward (toward its own far edge).
         let minDelta, maxDelta
         if (isEnd) {
-            minDelta = startRect[startKey] + 1 - startRect[cellKey]
+            minDelta = startGridArea[startKey] + 1 - startGridArea[cellKey]
             maxDelta = neighbors.length
                 ? Math.min(...neighbors.map(n => {
-                    const nr = startRects.get(n)
-                    return nr[endKey] - 1 - nr[neighborKey]
+                    const nga = startGridAreas.get(n)
+                    return nga[endKey] - 1 - nga[neighborKey]
                 }))
-                : (isVertical ? this.columnCount + 1 - startRect.colEnd : Infinity)
+                : (isVertical ? this.columnCount + 1 - startGridArea.colEnd : Infinity)
         } else {
-            maxDelta = startRect[endKey] - 1 - startRect[cellKey]
+            maxDelta = startGridArea[endKey] - 1 - startGridArea[cellKey]
             minDelta = neighbors.length
                 ? Math.max(...neighbors.map(n => {
-                    const nr = startRects.get(n)
-                    return nr[startKey] + 1 - nr[neighborKey]
+                    const nga = startGridAreas.get(n)
+                    return nga[startKey] + 1 - nga[neighborKey]
                 }))
-                : (1 - startRect[cellKey])
+                : (1 - startGridArea[cellKey])
         }
 
         const move = (ev) => {
@@ -390,33 +387,33 @@ export default class Mosaic extends KompElement {
 
             // Reset every frame so deltas apply to the start state, not the
             // accumulating intermediate one.
-            for (const [c, r] of startRects) working.set(c, { ...r })
+            for (const [c, ga] of startGridAreas) working.set(c, { ...ga })
 
             // Shift each neighbor's mirror line by `delta` so the boundary
             // moves in lockstep with the cell's edge.
             for (const n of neighbors) {
-                const ns = startRects.get(n)
-                working.set(n, { ...ns, [neighborKey]: ns[neighborKey] + delta })
+                const nga = startGridAreas.get(n)
+                working.set(n, { ...nga, [neighborKey]: nga[neighborKey] + delta })
             }
 
-            const newRect = { ...startRect, [cellKey]: startRect[cellKey] + delta }
+            const newGridArea = { ...startGridArea, [cellKey]: startGridArea[cellKey] + delta }
 
             // Run the cascade in case the cell grew into a non-adjacent cell.
-            this._resolveCollisions(cell, newRect, working)
-            for (const [c, r] of working) this._setRect(c, r)
+            this._resolveCollisions(cell, newGridArea, working)
+            for (const [c, ga] of working) this._setGridArea(c, ga)
         }
         const up = () => {
             window.removeEventListener('pointermove', move)
             handle.classList.remove('active')
             this.releasePointerCapture(e.pointerId)
-            this._emitGridAreaChanges(startRects)
-            const finalRect = this._rectOf(cell)
-            if (finalRect && finalRect[cellKey] !== startRect[cellKey]) {
+            const finalGridArea = this._getGridArea(cell)
+            if (finalGridArea && finalGridArea[cellKey] !== startGridArea[cellKey]) {
+                this._emitGridAreaChanges(startGridAreas)
                 this.trigger('resize', { detail: {
                     axis: isVertical ? 'column' : 'row',
                     edge,
                     cell,
-                    rect: finalRect
+                    gridArea: finalGridArea
                 }})
             }
         }
@@ -430,10 +427,10 @@ export default class Mosaic extends KompElement {
         this.classList.add('reordering')
         cell.classList.add('dragging')
 
-        const startRect = this._rectOf(cell)
-        if (!startRect) return
-        const colSpan = startRect.colEnd - startRect.colStart
-        const rowSpan = startRect.rowEnd - startRect.rowStart
+        const startGridArea = this._getGridArea(cell)
+        if (!startGridArea) return
+        const colSpan = startGridArea.colEnd - startGridArea.colStart
+        const rowSpan = startGridArea.rowEnd - startGridArea.rowStart
 
         const cellBR = cell.getBoundingClientRect()
         const myBR = this.getBoundingClientRect()
@@ -443,8 +440,8 @@ export default class Mosaic extends KompElement {
         const grabX = e.clientX - cellBR.left
         const grabY = e.clientY - cellBR.top
 
-        const startRects = this._snapshotRects()
-        const working = new Map(startRects)
+        const startGridAreas = this._snapshotGridAreas()
+        const working = new Map(startGridAreas)
 
         const clone = cell.cloneNode(true)
         clone.classList.add('komp-mosaic-drag-clone')
@@ -470,11 +467,11 @@ export default class Mosaic extends KompElement {
             let rowStart = Math.round(targetY / rowPx) + 1
             colStart = Math.max(1, Math.min(this.columnCount + 1 - colSpan, colStart))
             rowStart = Math.max(1, rowStart)
-            const newRect = { rowStart, colStart, rowEnd: rowStart + rowSpan, colEnd: colStart + colSpan }
+            const newGridArea = { rowStart, colStart, rowEnd: rowStart + rowSpan, colEnd: colStart + colSpan }
 
-            for (const [c, r] of startRects) working.set(c, { ...r })
-            this._resolveCollisions(cell, newRect, working)
-            for (const [c, r] of working) this._setRect(c, r)
+            for (const [c, ga] of startGridAreas) working.set(c, { ...ga })
+            this._resolveCollisions(cell, newGridArea, working)
+            for (const [c, ga] of working) this._setGridArea(c, ga)
         }
         const teardown = () => {
             window.removeEventListener('pointermove', move)
@@ -487,15 +484,15 @@ export default class Mosaic extends KompElement {
         }
         const up = () => {
             teardown()
-            this._emitGridAreaChanges(startRects)
-            const finalRect = this._rectOf(cell)
-            if (finalRect && (finalRect.rowStart !== startRect.rowStart || finalRect.colStart !== startRect.colStart)) {
-                this.trigger('reorder', { detail: { cell, rect: finalRect } })
+            const finalGridArea = this._getGridArea(cell)
+            if (finalGridArea && (finalGridArea.rowStart !== startGridArea.rowStart || finalGridArea.colStart !== startGridArea.colStart)) {
+                this._emitGridAreaChanges(startGridAreas)
+                this.trigger('reorder', { detail: { cell, gridArea: finalGridArea } })
             }
         }
         const keydown = (ev) => {
             if (ev.key !== 'Escape') return
-            for (const [c, r] of startRects) this._setRect(c, r)
+            for (const [c, ga] of startGridAreas) this._setGridArea(c, ga)
             teardown()
         }
         window.addEventListener('pointermove', move)
@@ -505,6 +502,7 @@ export default class Mosaic extends KompElement {
 
     static style = `
         komp-mosaic {
+            --select-rgb: 0, 0, 255; 
             display: grid;
             position: relative;
         }
@@ -517,10 +515,6 @@ export default class Mosaic extends KompElement {
             background: transparent;
             touch-action: none;
         }
-        /* Where a left/top handle shares a boundary with another cell's
-           right/bottom handle, the right/bottom one wins the click — its
-           cell can grow into the boundary; the opposing cell would need to
-           shrink (often impossible for 1-track cells). */
         komp-mosaic-handle[data-edge="right"],
         komp-mosaic-handle[data-edge="bottom"] {
             z-index: 6;
@@ -569,10 +563,10 @@ export default class Mosaic extends KompElement {
             block-size: 2px;
         }
         komp-mosaic-handle:hover::after {
-            background: rgba(0, 0, 255, 0.5);
+            background: rgba(var(--select-rgb), 0.5);
         }
         komp-mosaic-handle.active::after {
-            background: rgba(0, 0, 255, 0.9);
+            background: rgba(var(--select-rgb), 0.9);
         }
         komp-mosaic.reordering > *:not(komp-mosaic-handle):not(.komp-mosaic-drag-clone) {
             pointer-events: none;


### PR DESCRIPTION
## Summary
- New \`Mosaic\` component: a managed CSS-Grid container where each child cell declares its own \`grid-area\`.
- Per-edge resize handles (top/right/bottom/left). Adjacent neighbors split-resize in lockstep; non-aligned overlaps fall through to a cascading "bump down" collision pass.
- Drag-to-reorder snaps the cell to the grid line nearest the cursor; cells in the way are pushed down by the same cascade. Escape reverts.
- API: \`columnCount\` (default 12), \`rowHeight\` (default \`offsetWidth / columnCount\` via \`ResizeObserver\` — square cells), \`resizable\`, \`reorderable\`, \`handleSelector\`.

## Test plan
- [x] Open \`_docs/demo/mosaic.html\` after \`npm run demo\`.
- [x] Drag each edge of cell 1; confirm split-resize against cell 2 (right), against cell 4 (bottom, wider — should bump instead).
- [x] Drag the body of a cell to a new location; confirm cells beneath are bumped down.
- [x] Press Escape mid-reorder; layout reverts.
- [x] Toggle the \`columnCount\` and \`rowHeight\` inputs in the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)