### PR TITLE
Fix floater arrow alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - **`scanPrototypesFor` cache invalidation** — Cache entries now invalidate when the constructor's own-property status for a key flips. Without this, an instance constructed during class initialization (e.g. when `customElements.define` upgrades a pre-existing element before the subclass's `static <key> = ...` field has run) would lock in a result missing the subclass's own value, and every subsequent instance would inherit the wrong merged metadata.
+- **Floater arrow alignment** — The arrow now centers on its anchor. floating-ui measures the square `komp-floater-arrow-locator` and returns the cross-axis edge offset, but the visible `:after` was rendered at twice `--arrow-size` with centering math that left it half an arrow-width off (and clamped against the wrong width near the floater edges). The locator and arrow now share a single `--arrow-inset`/`--arrow-size`, and all four placements are handled with logical properties plus `writing-mode`.
 
 ### Breaking Changes
 

--- a/lib/komps/floater.js
+++ b/lib/komps/floater.js
@@ -221,15 +221,7 @@ export default class Floater extends KompElement {
 
         if (middlewareData.arrow) {
             const {x, y} = middlewareData.arrow;
-            const arrowLocator = this.querySelector('komp-floater-arrow-locator')
-            if (x != null) {
-                this.style.setProperty('--arrow-left', `${x}px`)
-                if (arrowLocator) arrowLocator.style.setProperty('left', `${x}px`)
-            }
-            if (y != null) {
-                this.style.setProperty('--arrow-top', `${y}px`)
-                if (arrowLocator) arrowLocator.style.setProperty('top', `${y}px`)
-            }
+            this.style.setProperty('--arrow-inset', `${x ?? y}px`)
         }
     }
     
@@ -351,19 +343,18 @@ export default class Floater extends KompElement {
     
     static style = `
         .komp-floater-arrow {
-            --arrow-size: 0.5em;
-            --arrow-left: 0;
-            --arrow-top: 0;
+            --arrow-size: 1em;
+            --arrow-inset: 0;
         }
         .komp-floater-arrow:after{
             content: '';
             clip-path: polygon(0 0, 50% 100%, 100% 0);
             z-index: 1;
             position:absolute;
-            top: calc(var(--arrow-top) - var(--arrow-size));
-            left: calc(var(--arrow-left) - var(--arrow-size));
-            width: calc(var(--arrow-size) * 2);
-            height: var(--arrow-size);
+            inset-block-start: 100%;
+            inset-inline-start: var(--arrow-inset);
+            inline-size: var(--arrow-size);
+            block-size: calc(var(--arrow-size) / 2);
             overflow: hidden;
             border-style: solid;
             border-width: inherit;
@@ -371,34 +362,31 @@ export default class Floater extends KompElement {
             background: inherit;
             border: inherit;
         }
-        .komp-floater-arrow.-top:after{
-            top: 100%;
-        }
-        .komp-floater-arrow.-bottom:after{
-            top: auto;
-            bottom: 100%;
-            transform: rotate(180deg);
-        }
+        
         .komp-floater-arrow.-left:after,
         .komp-floater-arrow.-right:after {
+            writing-mode: vertical-lr;
             clip-path: polygon(0 0, 100% 50%, 0 100%);
-            width: var(--arrow-size);
-            height: calc(var(--arrow-size) * 2);
         }
-        .komp-floater-arrow.-left:after{
-            left: 100%;
-        }
-        .komp-floater-arrow.-right:after{
-            left: auto;
-            right: 100%;
+        
+        .komp-floater-arrow.-right:after,
+        .komp-floater-arrow.-bottom:after{
+            inset-block-start: auto;
+            inset-block-end: 100%;
             transform: rotate(180deg);
         }
+        
+        /* Locator used by updatePosition */
         komp-floater-arrow-locator {
             position: absolute;
-            left: 0;
-            top: 0;
-            width: var(--arrow-size, 1px);
-            height: var(--arrow-size, 1px);
+            inset-inline-start: var(--arrow-inset);
+            inset-block-start: 0;
+            width: var(--arrow-size);
+            height: var(--arrow-size);
+        }
+        .komp-floater-arrow.-left komp-floater-arrow-locator,
+        .komp-floater-arrow.-right komp-floater-arrow-locator {
+            writing-mode: vertical-lr;
         }
     `
 }


### PR DESCRIPTION
## Summary
- The floater arrow was rendered half an arrow-width off-center. floating-ui measures the square `komp-floater-arrow-locator` and returns the **left edge** offset of that square, but the visible `:after` was `2 × --arrow-size` wide and positioned with `calc(var(--arrow-left) - var(--arrow-size))`, which centered it at floating-ui's `x` instead of `x + arrowSize/2`. The clamp floating-ui applies (to keep the arrow inside the floater) was also computed for the locator's width, not the wider visual, so it could drift/overflow near the edges.
- Fix: the locator and the rendered arrow now share a single `--arrow-inset` (the cross-axis value, `x ?? y`) and the same `--arrow-size`, so the measured box and the visual box line up and center on the anchor.
- All four placements are unified into one rule set using logical properties (`inset-inline-start` / `inset-block-start` / `inline-size` / `block-size`) plus `writing-mode: vertical-lr` for left/right, removing the per-placement `--arrow-left`/`--arrow-top` branches.

This follows [floating-ui's arrow convention](https://floating-ui.com/docs/arrow): a square arrow element positioned via `left`/`top` from `middlewareData.arrow`, with the static side pinned to the floater edge.

## Test plan
- [x] Arrow centers on the anchor for `top`/`bottom`/`left`/`right` placements
- [x] Arrow stays inside the floater (doesn't detach/overflow) when the anchor is near a viewport edge and shift clamps it
- [x] Custom `arrow` sizes (numeric px) still render and center correctly
- [x] Arrow tracks the anchor under scroll/resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)