### PR TITLE
Fix floater arrow alignment (1.x backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix floater arrow alignment — the arrow rendered half an arrow-width off-center because the visible `:after` was twice `--arrow-size` while floating-ui measures the square locator (and clamping used the wrong width near the floater edges). The locator and arrow now share a single `--arrow-inset`/`--arrow-size`, with all placements handled via logical properties and `writing-mode`.
+
 ## 1.5.0
 
 ### New Components

--- a/lib/komps/floater.js
+++ b/lib/komps/floater.js
@@ -210,15 +210,7 @@ export default class Floater extends KompElement {
 
         if (middlewareData.arrow) {
             const {x, y} = middlewareData.arrow;
-            const arrowLocator = this.querySelector('komp-floater-arrow-locator')
-            if (x != null) {
-                this.style.setProperty('--arrow-left', `${x}px`)
-                if (arrowLocator) arrowLocator.style.setProperty('left', `${x}px`)
-            }
-            if (y != null) {
-                this.style.setProperty('--arrow-top', `${y}px`)
-                if (arrowLocator) arrowLocator.style.setProperty('top', `${y}px`)
-            }
+            this.style.setProperty('--arrow-inset', `${x ?? y}px`)
         }
     }
     
@@ -327,19 +319,18 @@ export default class Floater extends KompElement {
     
     static style = `
         .komp-floater-arrow {
-            --arrow-size: 0.5em;
-            --arrow-left: 0;
-            --arrow-top: 0;
+            --arrow-size: 1em;
+            --arrow-inset: 0;
         }
         .komp-floater-arrow:after{
             content: '';
             clip-path: polygon(0 0, 50% 100%, 100% 0);
             z-index: 1;
             position:absolute;
-            top: calc(var(--arrow-top) - var(--arrow-size));
-            left: calc(var(--arrow-left) - var(--arrow-size));
-            width: calc(var(--arrow-size) * 2);
-            height: var(--arrow-size);
+            inset-block-start: 100%;
+            inset-inline-start: var(--arrow-inset);
+            inline-size: var(--arrow-size);
+            block-size: calc(var(--arrow-size) / 2);
             overflow: hidden;
             border-style: solid;
             border-width: inherit;
@@ -347,34 +338,31 @@ export default class Floater extends KompElement {
             background: inherit;
             border: inherit;
         }
-        .komp-floater-arrow.-top:after{
-            top: 100%;
-        }
-        .komp-floater-arrow.-bottom:after{
-            top: auto;
-            bottom: 100%;
-            transform: rotate(180deg);
-        }
+        
         .komp-floater-arrow.-left:after,
         .komp-floater-arrow.-right:after {
+            writing-mode: vertical-lr;
             clip-path: polygon(0 0, 100% 50%, 0 100%);
-            width: var(--arrow-size);
-            height: calc(var(--arrow-size) * 2);
         }
-        .komp-floater-arrow.-left:after{
-            left: 100%;
-        }
-        .komp-floater-arrow.-right:after{
-            left: auto;
-            right: 100%;
+        
+        .komp-floater-arrow.-right:after,
+        .komp-floater-arrow.-bottom:after{
+            inset-block-start: auto;
+            inset-block-end: 100%;
             transform: rotate(180deg);
         }
+        
+        /* Locator used by updatePosition */
         komp-floater-arrow-locator {
             position: absolute;
-            left: 0;
-            top: 0;
-            width: var(--arrow-size, 1px);
-            height: var(--arrow-size, 1px);
+            inset-inline-start: var(--arrow-inset);
+            inset-block-start: 0;
+            width: var(--arrow-size);
+            height: var(--arrow-size);
+        }
+        .komp-floater-arrow.-left komp-floater-arrow-locator,
+        .komp-floater-arrow.-right komp-floater-arrow-locator {
+            writing-mode: vertical-lr;
         }
     `
 }


### PR DESCRIPTION
Backport of #47 to the `1.x` maintenance branch.

## Summary
- The floater arrow rendered half an arrow-width off-center. floating-ui measures the square `komp-floater-arrow-locator` and returns the **left edge** offset of that square, but the visible `:after` was `2 × --arrow-size` wide and positioned with `calc(var(--arrow-left) - var(--arrow-size))`, centering it at floating-ui's `x` instead of `x + arrowSize/2`. The overflow clamp floating-ui applies was also computed for the locator's width, not the wider visual, so the arrow could drift/overflow near the edges.
- Fix: the locator and the rendered arrow now share a single `--arrow-inset` (the cross-axis value, `x ?? y`) and the same `--arrow-size`, so the measured box and the visual box line up and center on the anchor.
- All four placements are unified into one rule set using logical properties (`inset-inline-start` / `inset-block-start` / `inline-size` / `block-size`) plus `writing-mode: vertical-lr` for left/right.

The arrow code on `1.x` was identical to the pre-fix code on `main`, so the change applies unchanged. Floater positioning (transform, #42) is untouched — the arrow is a child and is unaffected by it.

## Test plan
- [ ] Arrow centers on the anchor for `top`/`bottom`/`left`/`right` placements
- [ ] Arrow stays inside the floater (doesn't detach/overflow) when shift clamps it near a viewport edge
- [ ] Custom `arrow` sizes (numeric px) still render and center correctly
- [ ] Arrow tracks the anchor under scroll/resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)