### PR TITLE
DataSpreadsheet: clipboard-permission fallback paste modal

### DIFF
--- a/lib/komps/data-spreadsheet.js
+++ b/lib/komps/data-spreadsheet.js
@@ -14,6 +14,7 @@ import { splitByUnquotedChar } from '../support.js';
 
 import DataGrid from './data-grid.js'
 import Floater from './floater.js'
+import Modal from './modal.js'
 import DataSpreadsheetCell from './data-spreadsheet/cell.js'
 
 import DataSpreadsheetColumn from './data-spreadsheet/column.js'
@@ -479,6 +480,82 @@ export default class DataSpreadsheet extends DataGrid {
         }))
     }
 
+    /**
+     * Read the system clipboard and paste it into the current selection. Use this for
+     * programmatic paste (e.g. a context-menu Paste action); the native `paste` event in
+     * {@link DataSpreadsheet#setupSelection} handles ⌘V/Ctrl+V directly. When the async
+     * Clipboard API or its permission is unavailable, fall back to {@link DataSpreadsheet#renderPasteModal}
+     * which explains the keyboard shortcuts.
+     */
+    async pasteFromClipboard() {
+        if (!window.navigator.permissions || !window.navigator.clipboard || !window.navigator.clipboard.readText) {
+            this.renderPasteModal()
+            return
+        }
+        try {
+            await window.navigator.permissions.query({
+                name: 'clipboard-read',
+                requestedOrigin: window.location.origin,
+            })
+            this.pasteData(await window.navigator.clipboard.readText())
+        } catch (e) {
+            this.renderPasteModal()
+        }
+    }
+
+    /**
+     * Fallback shown when the clipboard can't be read programmatically — explains the
+     * ⌘C/⌘X/⌘V (or Ctrl) shortcuts the user can still use.
+     */
+    renderPasteModal() {
+        const modifier = window.navigator.userAgent.toLowerCase().includes('mac') ? "&#8984;" : "Ctrl"
+        this.getRootNode().body.append(new Modal({
+            class: 'paste-modal',
+            content: [
+                {
+                    tag: 'h1',
+                    content: 'Copying and Pasting'
+                },
+                {
+                    tag: 'p',
+                    content: 'These actions are unavailable using the Edit menus, but you can still use:',
+                    style: {
+                        'margin-block': '1em'
+                    }
+                },
+                {
+                    class: 'flex text-center',
+                    style: {
+                        display: 'flex',
+                        gap: '1em',
+                    },
+                    content: [{
+                        content: [{
+                            tag: 'h1',
+                            content: `${modifier}C`
+                        }, {
+                            content: 'copy'
+                        }]
+                    }, {
+                        content: [{
+                            tag: 'h1',
+                            content: `${modifier}X`
+                        }, {
+                            content: 'cut'
+                        }]
+                    }, {
+                        content: [{
+                            tag: 'h1',
+                            content: `${modifier}V`
+                        }, {
+                            content: 'paste'
+                        }]
+                    }]
+                }
+            ]
+        }))
+    }
+
     clearSelectedCells() {
         const r = this.range()
         if (!r) return
@@ -582,6 +659,11 @@ export default class DataSpreadsheet extends DataGrid {
         }
         .${this.tagName}-input > label > input {
             width: 1px; // make so doesn't initially overflow column
+        }
+
+        komp-modal.paste-modal {
+            background: white;
+            padding: 1em;
         }
     `}
 


### PR DESCRIPTION
## Summary

Ports the non-virtualized `Spreadsheet`'s clipboard-permission fallback to the virtualized `DataSpreadsheet`.

- Adds `renderPasteModal()` — builds a `Modal` (`.paste-modal`) explaining the ⌘C/⌘X/⌘V (or Ctrl) shortcuts, with mac-vs-other modifier detection, appended to the root `body`. Mirrors `Spreadsheet.renderPasteModal()` in content and structure.
- Adds an async `pasteFromClipboard()` helper that attempts `navigator.permissions.query({name:'clipboard-read'})` → `navigator.clipboard.readText()` → `pasteData(text)`, and falls back to `renderPasteModal()` when the Clipboard API or its permission is unavailable. This gives the upcoming context-menu PR a clean method to call while providing the fallback now.
- Adds the `komp-modal.paste-modal` rule to `static style` using the `${this.tagName}` interpolation pattern.

Native ⌘C/⌘V copy/paste event handling in `setupSelection()` is unchanged. `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)