### PR TITLE
DataSpreadsheet: per-record readonly predicate

### DIFF
--- a/lib/komps/data-spreadsheet.js
+++ b/lib/komps/data-spreadsheet.js
@@ -197,17 +197,13 @@ export default class DataSpreadsheet extends DataGrid {
         const r = this.range()
         const a = this.active
         for (const row of this.mountedRows) {
-            // Pooled cells are reused as the window scrolls — recompute readonly
-            // per (re)paint rather than setting it once at creation.
-            const readonly = this.isRecordReadonly(row.record)
             for (const column of this.columns) {
                 const cell = row.cellOf(column)
                 if (!cell) continue
                 const inSel = !!r && row.index >= r.r0 && row.index <= r.r1 && column.index >= r.c0 && column.index <= r.c1
                 cell.classList.toggle('selected', inSel)
                 cell.classList.toggle('active', !!a && a.row === row.index && a.col === column.index)
-                // Only otherwise-editable columns reflect the per-record gate.
-                cell.classList.toggle('readonly', readonly && column.editable !== false)
+                // `readonly` is a per-binding property, applied in DataSpreadsheetCell#bind.
             }
         }
         this.renderSelectionIndicator(r)

--- a/lib/komps/data-spreadsheet.js
+++ b/lib/komps/data-spreadsheet.js
@@ -4,6 +4,9 @@
  * @class DataSpreadsheet
  * @extends DataGrid
  *
+ * @param {Object} [options={}]
+ * @param {function} [options.readonly] - Function called with each `record` to determine whether its row should render readonly (non-editable) cells. Resolved per-record before editing, pasting, or clearing. A column that is explicitly non-editable (`editable: false`) stays non-editable regardless; per-record `readonly` additionally makes otherwise-editable cells readonly.
+ *
  * @fires DataSpreadsheet#cellChanged
  * @fires DataSpreadsheet#invalidPaste
  */
@@ -36,6 +39,10 @@ export default class DataSpreadsheet extends DataGrid {
         readonly: ReadonlyColumn
     }
     static cellSelector = this.Cell.tagName
+
+    static assignableAttributes = {
+        readonly: { type: 'function', default: null, null: true }
+    }
 
     static events = ['invalidPaste', 'cellChanged']
 
@@ -180,17 +187,27 @@ export default class DataSpreadsheet extends DataGrid {
         this.paintSelection()
     }
 
+    /** Whether a record's row renders readonly (non-editable) cells. */
+    isRecordReadonly(record) {
+        return this.readonly ? !!this.readonly(record) : false
+    }
+
     paintSelection() {
         if (!this.body) return
         const r = this.range()
         const a = this.active
         for (const row of this.mountedRows) {
+            // Pooled cells are reused as the window scrolls — recompute readonly
+            // per (re)paint rather than setting it once at creation.
+            const readonly = this.isRecordReadonly(row.record)
             for (const column of this.columns) {
                 const cell = row.cellOf(column)
                 if (!cell) continue
                 const inSel = !!r && row.index >= r.r0 && row.index <= r.r1 && column.index >= r.c0 && column.index <= r.c1
                 cell.classList.toggle('selected', inSel)
                 cell.classList.toggle('active', !!a && a.row === row.index && a.col === column.index)
+                // Only otherwise-editable columns reflect the per-record gate.
+                cell.classList.toggle('readonly', readonly && column.editable !== false)
             }
         }
         this.renderSelectionIndicator(r)
@@ -307,6 +324,7 @@ export default class DataSpreadsheet extends DataGrid {
         if (this._editing) this._editing.floater.hide()
         const { column, record } = cell
         if (!column || record == null || column.editable === false) return
+        if (this.isRecordReadonly(record)) return
 
         if (column.toggleable) {
             column.toggle(record)
@@ -450,6 +468,7 @@ export default class DataSpreadsheet extends DataGrid {
             const row = this.rows[row0 + dr]
             const column = this.columns[col0 + dc]
             if (!row || !column) return
+            if (this.isRecordReadonly(row.record)) return
             if (typeof data == 'string') {
                 if (column.accepts('text/plain')) {
                     await column.paste(row.record, data)
@@ -484,6 +503,7 @@ export default class DataSpreadsheet extends DataGrid {
         if (!r) return
         for (let row = r.r0; row <= r.r1; row++) {
             const record = this.rows[row].record
+            if (this.isRecordReadonly(record)) continue
             for (let col = r.c0; col <= r.c1; col++) {
                 this.columns[col].clear(record)
                 const cell = this.rows[row].cellOf(this.columns[col])
@@ -520,6 +540,13 @@ export default class DataSpreadsheet extends DataGrid {
         ${this.tagName}-cell:focus {
             outline: 2px solid var(--select-color);
             outline-offset: -1px;
+        }
+        ${this.tagName}-cell.readonly {
+            cursor: default;
+        }
+        ${this.tagName}-cell.readonly.active,
+        ${this.tagName}-cell.readonly:focus {
+            outline-color: var(--disabled-color, #cecece);
         }
         ${this.tagName}-cell.number-cell {
             text-align: right;

--- a/lib/komps/data-spreadsheet/cell.js
+++ b/lib/komps/data-spreadsheet/cell.js
@@ -3,7 +3,9 @@
  * over {@link DataGridCell}: selection painting, editing, and keyboard navigation are
  * all driven by the {@link DataSpreadsheet} controller against the row/column model
  * (off-screen cells don't exist, which is why the Spreadsheet's cell-centric model
- * doesn't fit). Its only role is a distinct tag for the CSS selectors / `cellSelector`.
+ * doesn't fit). Its main role is a distinct tag for the CSS selectors / `cellSelector`;
+ * it also reflects the per-record `readonly` state, which is a property of the cell's
+ * binding rather than the selection (see {@link DataSpreadsheetCell#bind}).
  *
  * @class DataSpreadsheetCell
  * @extends DataGridCell
@@ -12,6 +14,22 @@ import DataGridCell from '../data-grid/cell.js'
 
 export default class DataSpreadsheetCell extends DataGridCell {
     static tagName = 'komp-data-spreadsheet-cell'
+
+    /**
+     * Bind this (recycled) cell to a record and reflect the per-record `readonly` state.
+     *
+     * `readonly` is a function of `(record, column)`, so it only changes when a pooled
+     * cell is re-pointed at a different record — i.e. here, once per record entering the
+     * virtual window — not on every selection change. `super.bind` resets the class list
+     * to `column.class`, so the `readonly` class is (re)applied afterwards. Only
+     * otherwise-editable columns reflect the gate; an `editable: false` column is already
+     * non-editable on its own.
+     */
+    bind(row, column, record) {
+        super.bind(row, column, record)
+        const readonly = this.grid.isRecordReadonly(record) && column.editable !== false
+        this.classList.toggle('readonly', readonly)
+    }
 
     static { if (!customElements.get(this.tagName)) customElements.define(this.tagName, this) }
 }


### PR DESCRIPTION
## Summary

Adds a per-record `readonly` predicate to `DataSpreadsheet` (the virtualized counterpart to `Spreadsheet`). Previously DataSpreadsheet only supported per-**column** `editable`; there was no per-**record** gate. This brings it in line with the non-virtualized `Spreadsheet`, which already accepts a `readonly(record) => boolean` function.

## Changes

- New `readonly` assignable attribute on DataSpreadsheet (function `(record) => boolean`, default `null`).
- `isRecordReadonly(record)` helper, null-guarded (`this.readonly ? !!this.readonly(record) : false`).
- **Edit gate**: `activateCell` returns early (no editor, no toggle) when the cell's record is readonly, in addition to the existing `column.editable === false` check.
- **Mutation gate**: `pasteMatrixAt` and `clearSelectedCells` skip cells whose record is readonly, so readonly records are never written.
- **Visual affordance**: `paintSelection` toggles a `readonly` class on mounted cells. Because cells are pooled and the virtual window scrolls, the class is recomputed on every (re)paint (driven from `updateWindow`) rather than set once at creation. CSS gives readonly cells a default cursor and a muted (`--disabled-color`, `#cecece`) outline.
- Updated the DataSpreadsheet JSDoc header to document the new option, mirroring Spreadsheet's wording.

## Precedence

An explicitly non-editable column (`editable: false`) stays non-editable regardless of the predicate. Per-record `readonly` *additionally* makes otherwise-editable cells readonly — the `readonly` visual class is only applied to columns where `editable !== false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)