### PR TITLE
DataGrid: collapsible plugin (row truncation + expand toggles)

### DIFF
--- a/docs/demo/pages/data-spreadsheet.html
+++ b/docs/demo/pages/data-spreadsheet.html
@@ -21,12 +21,9 @@ title: Data Spreadsheet
     }
     komp-data-spreadsheet-cell {
         padding: .4em .6em;
-        border-right: 1px solid hsl(0,0%,85%);
+        border-right: 1px solid hsl(0,0%,85%); border-bottom: 1px solid hsl(0,0%,85%);
         white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     }
-    /* Horizontal grid lines live on the row, not the cells: an inset shadow paints at
-       the row's used (clamped) box, so collapsible's truncation can't clip it away. */
-    komp-data-spreadsheet-row { box-shadow: inset 0 -1px 0 hsl(0,0%,85%); }
     komp-data-spreadsheet-cell.frozen,
     komp-data-spreadsheet-header-cell.frozen { box-shadow: 1px 0 0 #ddd; }
     komp-data-spreadsheet-cell.wrap { white-space: pre-line; }

--- a/docs/demo/pages/data-spreadsheet.html
+++ b/docs/demo/pages/data-spreadsheet.html
@@ -21,9 +21,12 @@ title: Data Spreadsheet
     }
     komp-data-spreadsheet-cell {
         padding: .4em .6em;
-        border-right: 1px solid hsl(0,0%,85%); border-bottom: 1px solid hsl(0,0%,85%);
+        border-right: 1px solid hsl(0,0%,85%);
         white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     }
+    /* Horizontal grid lines live on the row, not the cells: an inset shadow paints at
+       the row's used (clamped) box, so collapsible's truncation can't clip it away. */
+    komp-data-spreadsheet-row { box-shadow: inset 0 -1px 0 hsl(0,0%,85%); }
     komp-data-spreadsheet-cell.frozen,
     komp-data-spreadsheet-header-cell.frozen { box-shadow: 1px 0 0 #ddd; }
     komp-data-spreadsheet-cell.wrap { white-space: pre-line; }

--- a/docs/demo/pages/data-spreadsheet.html
+++ b/docs/demo/pages/data-spreadsheet.html
@@ -26,6 +26,7 @@ title: Data Spreadsheet
     }
     komp-data-spreadsheet-cell.frozen,
     komp-data-spreadsheet-header-cell.frozen { box-shadow: 1px 0 0 #ddd; }
+    komp-data-spreadsheet-cell.wrap { white-space: pre-line; }
 </style>
 
 <div id="status">loading…</div>
@@ -33,10 +34,11 @@ title: Data Spreadsheet
 
 <script type="module">
     import DataSpreadsheet from './lib/komps/data-spreadsheet.js';
-    import { resizable, reorderable } from './lib/komps/data-grid/plugins.js';
+    import { resizable, reorderable, collapsible } from './lib/komps/data-grid/plugins.js';
 
     DataSpreadsheet.include(resizable);
     DataSpreadsheet.include(reorderable);
+    DataSpreadsheet.include(collapsible);
 
     const db = await fetch('/nba-players.json').then(r => r.json());
     const players = db.players;
@@ -45,6 +47,7 @@ title: Data Spreadsheet
 
     const grid = new DataSpreadsheet({
         data: players,
+        collapseTo: '60px',
         columns: [
             { header: 'Player', width: 170, frozen: true, type: 'readonly',
               render: r => `${r.firstName} ${r.lastName}` },
@@ -56,7 +59,9 @@ title: Data Spreadsheet
             { header: 'Wt', width: 64, type: 'number', attribute: 'weight' },
             { header: 'Born', width: 64, type: 'readonly', render: r => r.born?.year ?? '' },
             { header: 'Contract', width: 100, type: 'readonly',
-              render: r => r.contract ? '$' + r.contract.amount.toLocaleString() : '' }
+              render: r => r.contract ? '$' + r.contract.amount.toLocaleString() : '' },
+            { header: 'Awards', width: 240, type: 'readonly', class: 'wrap',
+              render: r => (r.awards || []).map(a => `${a.season} ${a.type}`).join('\n') }
         ]
     });
     document.getElementById('container').append(grid);
@@ -67,7 +72,7 @@ title: Data Spreadsheet
         const sel = r ? `${(r.r1-r.r0+1)}×${(r.c1-r.c0+1)} selected` : 'no selection';
         status.innerHTML = `Editable + virtualized · mounted <b>${grid.mountedRows.length}</b> of ` +
             `<b>${grid.rows.length}</b> rows · ${sel} · ` +
-            `<i>click to select, drag/shift-arrows to extend, type or Enter to edit, ⌘C/⌘V to copy/paste, drag a column/row edge to resize, drag the grip to reorder</i>`;
+            `<i>click to select, drag/shift-arrows to extend, type or Enter to edit, ⌘C/⌘V to copy/paste, drag a column/row edge to resize, drag the grip to reorder, click a ▾ to expand a truncated row</i>`;
     };
     grid.addEventListener('rendered', update);
     grid.addEventListener('cellChanged', update);

--- a/lib/komps/data-grid.js
+++ b/lib/komps/data-grid.js
@@ -406,6 +406,7 @@ export default class DataGrid extends KompElement {
             box-sizing: border-box;
             overflow: hidden;
             min-width: 0;
+            grid-row: 1;
         }
         ${this.tagName}-cell.frozen,
         ${this.tagName}-header-cell.frozen {

--- a/lib/komps/data-grid/plugins.js
+++ b/lib/komps/data-grid/plugins.js
@@ -1,2 +1,3 @@
 export { default as resizable } from './plugins/resizable.js';
 export { default as reorderable } from './plugins/reorderable.js';
+export { default as collapsible } from './plugins/collapsible.js';

--- a/lib/komps/data-grid/plugins/collapsible.js
+++ b/lib/komps/data-grid/plugins/collapsible.js
@@ -1,0 +1,277 @@
+/**
+ * A plugin to make a {@link DataGrid} (and its subclasses, e.g. {@link DataSpreadsheet})
+ * **collapsible** by grouping its (virtualized) rows under collapsible group headers.
+ *
+ * Rows are grouped by a key (or a key function); each group is preceded by a **group
+ * header row** that toggles its members open/closed on click. Because DataGrid is
+ * windowed, collapsing must change both *which* rows are mounted and the *total scroll
+ * height* — this plugin does that by keeping the group structure as the source of truth
+ * and projecting the currently-visible entries (always-visible headers + expanded
+ * members) back onto `grid.rows`. The existing geometry/windowing pipeline
+ * (`rowGeometry`, `updateWindow()`, the body scrollbar) then works unchanged: a
+ * collapsed group simply contributes one header row's worth of height instead of all
+ * its members.
+ *
+ * The group header itself is an ordinary {@link DataGridRow} flagged `isGroupHeader`,
+ * so it scrolls, mounts/unmounts, and measures like any other row. A custom render path
+ * paints it as a single full-width banner (using the grid's existing `-cell` element with
+ * a `group-header` class) carrying the group label, member count, and a twirl-down
+ * caret affordance.
+ *
+ * @function Plugin/DataGridCollapsible
+ * @mixin
+ *
+ * @param {Object} [options={}] - Options added to the grid
+ * @param {string|function|null} [options.groupBy=null] - How to group rows. A string reads
+ *   that key off each record; a function `(record, row, grid) => groupKey` returns the key.
+ *   `null` (default) disables grouping — no headers are inserted and the grid is left ungrouped.
+ * @param {function} [options.groupHeader] - Render the group header label; receives
+ *   `(groupKey, members, grid)` and returns content (string / node / dolla descriptor).
+ *   Defaults to `"<key> (<count>)"`.
+ * @param {boolean} [options.collapsed=false] - Initial collapsed state for every group.
+ *
+ * @fires Plugin/DataGridCollapsible#groupToggled
+ *
+ * @example <caption>JS — DataGrid</caption>
+ * import DataGrid from 'komps/komps/data-grid.js'
+ * import { collapsible } from 'komps/komps/data-grid/plugins.js'
+ * DataGrid.include(collapsible)
+ * new DataGrid({
+ *     style: 'height: 400px',
+ *     groupBy: 'team',                 // or: record => record.team
+ *     collapsed: false,                // start expanded
+ *     data: [...],
+ *     columns: [...]
+ * })
+ *
+ * @example <caption>JS — DataSpreadsheet</caption>
+ * import DataSpreadsheet from 'komps/komps/data-spreadsheet.js'
+ * import { collapsible } from 'komps/komps/data-grid/plugins.js'
+ * DataSpreadsheet.include(collapsible)
+ * new DataSpreadsheet({ groupBy: r => r.category, data: [...], columns: [...] })
+ */
+
+/**
+ * Fired after a group is expanded or collapsed (re-windows synchronously before firing).
+ * @event Plugin/DataGridCollapsible#groupToggled
+ * @type {Object}
+ * @property {*} key - the group key that was toggled
+ * @property {boolean} collapsed - the new collapsed state
+ */
+
+import { content as renderContent } from 'dolla'
+
+export default function (proto) {
+    // assignableAttributes is shared up the prototype chain; clone before adding so a
+    // plugin included on a subclass (DataSpreadsheet) doesn't leak options onto DataGrid.
+    if (!Object.hasOwn(this, 'assignableAttributes')) {
+        this.assignableAttributes = { ...this.assignableAttributes }
+    }
+    this.assignableAttributes.groupBy = { type: ['string', 'function'], default: null, null: true }
+    this.assignableAttributes.groupHeader = { type: 'function', default: null, null: true }
+    this.assignableAttributes.collapsed = { type: 'boolean', default: false, null: false }
+
+    this.events.push('groupToggled')
+
+    /* -----------------------------------------------------------------
+       Setup — after rows are built, partition them into groups and insert
+       a header row per group, then project the visible set onto grid.rows
+       (this runs before renderScaffold/updateWindow in DataGrid.initialize).
+    ----------------------------------------------------------------- */
+    const initializeRowsWas = proto.initializeRows
+    proto.initializeRows = async function (...args) {
+        await initializeRowsWas.call(this, ...args)
+        if (this.groupBy != null) this.buildGroups()
+        return this.rows
+    }
+
+    /** Resolve the group key for a row's record. */
+    proto.groupKeyOf = function (row) {
+        if (typeof this.groupBy === 'function') return this.groupBy(row.record, row, this)
+        return row.record == null ? undefined : row.record[this.groupBy]
+    }
+
+    /**
+     * Partition the data rows into groups (stable: group order follows first
+     * appearance, member order is preserved), create one header row per group, and
+     * build the authoritative ordered list `this._groupOrder` of entries:
+     * `{ header, members: [DataGridRow], collapsed }`. Then project the visible
+     * entries onto `this.rows`.
+     */
+    proto.buildGroups = function () {
+        const dataRows = this.rows.filter(r => !r.isGroupHeader)
+        const groups = new Map() // key -> { header, members, collapsed }
+        for (const row of dataRows) {
+            const key = this.groupKeyOf(row)
+            let group = groups.get(key)
+            if (!group) {
+                const header = new this.constructor.Row({ grid: this, index: 0, record: null })
+                header.isGroupHeader = true
+                header.groupKey = key
+                header.collapsed = !!this.collapsed
+                group = { key, header, members: [] }
+                header.group = group
+                groups.set(key, group)
+            }
+            group.members.push(row)
+            row.group = group
+        }
+        this._groups = groups
+        this.projectVisibleRows()
+    }
+
+    /**
+     * Rebuild `this.rows` from the group structure: every header is visible; a group's
+     * members are visible only while it is expanded. This is the integration point with
+     * virtualization — geometry, windowing, and the scrollbar all consume `this.rows`,
+     * so a collapsed group contributes only its (one) header row to the total height.
+     */
+    proto.projectVisibleRows = function () {
+        const out = []
+        for (const group of this._groups.values()) {
+            out.push(group.header)
+            if (!group.header.collapsed) out.push(...group.members)
+        }
+        this.rows = out
+        this.reindexRows(0)
+        // Keep the geometry's element list pointed at the new array, then re-sum.
+        if (this.rowGeometry) {
+            this.rowGeometry.elements = this.rows
+            this.rowGeometry.rebuildFrom(0)
+        }
+    }
+
+    /* -----------------------------------------------------------------
+       Group-header rendering — a header row paints as a single full-width
+       banner instead of per-column cells. We override the row controller's
+       renderCells for header rows; data rows fall through to the original.
+    ----------------------------------------------------------------- */
+    const renderCellsWas = this.Row.prototype.renderCells
+    this.Row.prototype.renderCells = function (...args) {
+        if (!this.isGroupHeader) return renderCellsWas.call(this, ...args)
+        this.grid.renderGroupHeaderCells(this)
+    }
+
+    proto.renderGroupHeaderCells = function (row) {
+        row.cellsByColumn = new Map()
+        const cell = this.acquireCell()
+        // Bind to the first column so pooled-cell bookkeeping (column.cells) stays sane,
+        // then override its layout to span the full row as a banner.
+        const column = this.columns[0]
+        if (column) {
+            cell.bind(row, column, null)
+            column.cells.add(cell)
+            row.cellsByColumn.set(column, cell)
+        } else {
+            cell.row = row
+        }
+        cell.classList.add('group-header')
+        cell.classList.remove('frozen')
+        cell.style.gridColumn = '1 / -1'
+        cell.style.left = ''
+        cell.removeAttribute('role')
+        cell.toggleAttribute('collapsed', !!row.collapsed)
+
+        const label = this.groupHeader
+            ? this.groupHeader(row.groupKey, row.group.members, this)
+            : `${row.groupKey == null ? '' : row.groupKey} (${row.group.members.length})`
+
+        renderContent(cell, {
+            tag: `${this.localName}-group-toggle`,
+            content: [
+                {
+                    tag: 'svg',
+                    xmlns: 'http://www.w3.org/2000/svg',
+                    width: '12', height: '12', viewBox: '0 0 24 24',
+                    fill: 'none', stroke: 'currentColor', 'stroke-width': '3',
+                    'stroke-linecap': 'round', 'stroke-linejoin': 'round',
+                    class: 'caret',
+                    content: { tag: 'polyline', points: '6 9 12 15 18 9' }
+                },
+                { tag: `${this.localName}-group-label`, content: label }
+            ]
+        })
+
+        cell.addEventListener('click', () => this.toggleGroup(row.groupKey))
+        row.element.appendChild(cell)
+    }
+
+    /* -----------------------------------------------------------------
+       Toggle — flip the group's collapsed flag, re-project the visible set,
+       rebuild the window so the mounted rows + scrollbar reflect the change.
+    ----------------------------------------------------------------- */
+    /** Collapse or expand a group by its key (no-op if the key is unknown). */
+    proto.toggleGroup = function (key, collapsed) {
+        const group = this._groups && this._groups.get(key)
+        if (!group) return
+        const next = collapsed == null ? !group.header.collapsed : !!collapsed
+        if (next === group.header.collapsed) return
+        group.header.collapsed = next
+
+        // The mounted set may now hold members of a freshly-collapsed group (or be
+        // missing newly-revealed ones) — drop them all and re-window from scratch.
+        for (const r of Array.from(this.mounted)) r.unmount()
+        this.projectVisibleRows()
+        this.updateWindow()
+        this.trigger('groupToggled', { detail: { key, collapsed: next } })
+    }
+
+    /** Collapse every group. */
+    proto.collapseAll = function () { this._setAllCollapsed(true) }
+    /** Expand every group. */
+    proto.expandAll = function () { this._setAllCollapsed(false) }
+    proto._setAllCollapsed = function (state) {
+        if (!this._groups) return
+        let changed = false
+        for (const group of this._groups.values()) {
+            if (group.header.collapsed !== state) { group.header.collapsed = state; changed = true }
+        }
+        if (!changed) return
+        for (const r of Array.from(this.mounted)) r.unmount()
+        this.projectVisibleRows()
+        this.updateWindow()
+    }
+
+    /* -----------------------------------------------------------------
+       Styles — full-width banner + twirl caret for the group header rows.
+    ----------------------------------------------------------------- */
+    if (!Array.isArray(this.style)) this.style = [this.style]
+    this.style.push(function () { return `
+        ${this.tagName}-cell.group-header {
+            grid-column: 1 / -1;
+            position: sticky;
+            left: 0;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            box-sizing: border-box;
+            inline-size: var(--dg-width);
+            padding: 4px 8px;
+            font-weight: 600;
+            background: var(--dg-group-header-bg, #f3f4f6);
+            border-block-end: 1px solid var(--dg-group-header-border, #e5e7eb);
+            cursor: pointer;
+            user-select: none;
+            -webkit-user-select: none;
+            z-index: 6;
+        }
+        ${this.tagName}-cell.group-header:hover {
+            background: var(--dg-group-header-bg-hover, #e9eaed);
+        }
+        ${this.tagName}-group-toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+        ${this.tagName}-group-toggle .caret {
+            flex: none;
+            transition: transform 0.12s ease;
+        }
+        ${this.tagName}-cell.group-header[collapsed] .caret {
+            transform: rotate(-90deg);
+        }
+        ${this.tagName}-group-label {
+            display: inline-block;
+        }
+    `})
+}

--- a/lib/komps/data-grid/plugins/collapsible.js
+++ b/lib/komps/data-grid/plugins/collapsible.js
@@ -1,65 +1,40 @@
 /**
- * A plugin to make a {@link DataGrid} (and its subclasses, e.g. {@link DataSpreadsheet})
- * **collapsible** by grouping its (virtualized) rows under collapsible group headers.
+ * A plugin to make a {@link DataGrid}'s (and its subclasses', e.g. {@link DataSpreadsheet})
+ * rows **collapsible** — the windowed counterpart of the Table `collapsible` plugin.
  *
- * Rows are grouped by a key (or a key function); each group is preceded by a **group
- * header row** that toggles its members open/closed on click. Because DataGrid is
- * windowed, collapsing must change both *which* rows are mounted and the *total scroll
- * height* — this plugin does that by keeping the group structure as the source of truth
- * and projecting the currently-visible entries (always-visible headers + expanded
- * members) back onto `grid.rows`. The existing geometry/windowing pipeline
- * (`rowGeometry`, `updateWindow()`, the body scrollbar) then works unchanged: a
- * collapsed group simply contributes one header row's worth of height instead of all
- * its members.
+ * The app sets a height budget for rows via `collapseTo` (any valid CSS size). Rows whose
+ * cell content overflows that budget are truncated, flagged with a `collapsed` attribute,
+ * and each overflowing cell gets a toggle that expands the row to that cell's full content
+ * (and back). Expanding sizes the row via `--expandTo`; the grid's normal measure/reflow
+ * pipeline picks the new height up, so offsets, the mounted window, and the body scroll
+ * extent stay correct.
  *
- * The group header itself is an ordinary {@link DataGridRow} flagged `isGroupHeader`,
- * so it scrolls, mounts/unmounts, and measures like any other row. A custom render path
- * paints it as a single full-width banner (using the grid's existing `-cell` element with
- * a `group-header` class) carrying the group label, member count, and a twirl-down
- * caret affordance.
+ * Because DataGrid pools and recycles its row and cell elements, the expanded state is
+ * kept on the persistent {@link DataGridRow} controller (`row.expandedColumns`, a Set of
+ * {@link DataGridColumn}s) and re-applied to whatever live elements the row currently has
+ * each time it (re)mounts or resizes — measured row heights already travel with the
+ * controller, so an expanded row scrolled out of the window keeps its height and restores
+ * its expansion when it scrolls back in.
  *
  * @function Plugin/DataGridCollapsible
  * @mixin
  *
  * @param {Object} [options={}] - Options added to the grid
- * @param {string|function|null} [options.groupBy=null] - How to group rows. A string reads
- *   that key off each record; a function `(record, row, grid) => groupKey` returns the key.
- *   `null` (default) disables grouping — no headers are inserted and the grid is left ungrouped.
- * @param {function} [options.groupHeader] - Render the group header label; receives
- *   `(groupKey, members, grid)` and returns content (string / node / dolla descriptor).
- *   Defaults to `"<key> (<count>)"`.
- * @param {boolean} [options.collapsed=false] - Initial collapsed state for every group.
+ * @param {string} [options.collapseTo='auto'] - Valid CSS size for the rows' max-height
  *
- * @fires Plugin/DataGridCollapsible#groupToggled
- *
- * @example <caption>JS — DataGrid</caption>
+ * @example <caption>JS</caption>
  * import DataGrid from 'komps/komps/data-grid.js'
  * import { collapsible } from 'komps/komps/data-grid/plugins.js'
  * DataGrid.include(collapsible)
  * new DataGrid({
  *     style: 'height: 400px',
- *     groupBy: 'team',                 // or: record => record.team
- *     collapsed: false,                // start expanded
+ *     collapseTo: '50px',
  *     data: [...],
  *     columns: [...]
  * })
- *
- * @example <caption>JS — DataSpreadsheet</caption>
- * import DataSpreadsheet from 'komps/komps/data-spreadsheet.js'
- * import { collapsible } from 'komps/komps/data-grid/plugins.js'
- * DataSpreadsheet.include(collapsible)
- * new DataSpreadsheet({ groupBy: r => r.category, data: [...], columns: [...] })
  */
 
-/**
- * Fired after a group is expanded or collapsed (re-windows synchronously before firing).
- * @event Plugin/DataGridCollapsible#groupToggled
- * @type {Object}
- * @property {*} key - the group key that was toggled
- * @property {boolean} collapsed - the new collapsed state
- */
-
-import { content as renderContent } from 'dolla'
+import { createElement, listenerElement } from 'dolla'
 
 export default function (proto) {
     // assignableAttributes is shared up the prototype chain; clone before adding so a
@@ -67,211 +42,200 @@ export default function (proto) {
     if (!Object.hasOwn(this, 'assignableAttributes')) {
         this.assignableAttributes = { ...this.assignableAttributes }
     }
-    this.assignableAttributes.groupBy = { type: ['string', 'function'], default: null, null: true }
-    this.assignableAttributes.groupHeader = { type: 'function', default: null, null: true }
-    this.assignableAttributes.collapsed = { type: 'boolean', default: false, null: false }
+    this.assignableAttributes.collapseTo = { type: 'string', default: 'auto', null: false }
 
-    this.events.push('groupToggled')
-
-    /* -----------------------------------------------------------------
-       Setup — after rows are built, partition them into groups and insert
-       a header row per group, then project the visible set onto grid.rows
-       (this runs before renderScaffold/updateWindow in DataGrid.initialize).
-    ----------------------------------------------------------------- */
-    const initializeRowsWas = proto.initializeRows
-    proto.initializeRows = async function (...args) {
-        await initializeRowsWas.call(this, ...args)
-        if (this.groupBy != null) this.buildGroups()
-        return this.rows
+    proto.collapseToChanged = function (was, now) {
+        this.style.setProperty('--collapseTo', now)
     }
 
-    /** Resolve the group key for a row's record. */
-    proto.groupKeyOf = function (row) {
-        if (typeof this.groupBy === 'function') return this.groupBy(row.record, row, this)
-        return row.record == null ? undefined : row.record[this.groupBy]
-    }
-
-    /**
-     * Partition the data rows into groups (stable: group order follows first
-     * appearance, member order is preserved), create one header row per group, and
-     * build the authoritative ordered list `this._groupOrder` of entries:
-     * `{ header, members: [DataGridRow], collapsed }`. Then project the visible
-     * entries onto `this.rows`.
-     */
-    proto.buildGroups = function () {
-        const dataRows = this.rows.filter(r => !r.isGroupHeader)
-        const groups = new Map() // key -> { header, members, collapsed }
-        for (const row of dataRows) {
-            const key = this.groupKeyOf(row)
-            let group = groups.get(key)
-            if (!group) {
-                const header = new this.constructor.Row({ grid: this, index: 0, record: null })
-                header.isGroupHeader = true
-                header.groupKey = key
-                header.collapsed = !!this.collapsed
-                group = { key, header, members: [] }
-                header.group = group
-                groups.set(key, group)
+    const initializeWas = proto.initialize
+    proto.initialize = function (...args) {
+        // Re-check a row whenever its element resizes: content rendering in, --expandTo
+        // changing, a column resize rewrapping cells. Observation also fires when it
+        // starts, which gives each row its first check on mount (see syncMounted below).
+        this.collapseObserver = new ResizeObserver(entries => {
+            for (const entry of entries) {
+                if (entry.target.row) this.checkRowCollapse(entry.target.row)
             }
-            group.members.push(row)
-            row.group = group
-        }
-        this._groups = groups
-        this.projectVisibleRows()
+        })
+        return initializeWas.call(this, ...args)
+    }
+
+    const disconnectedWas = proto.disconnected
+    proto.disconnected = function (...args) {
+        this.collapseObserver.disconnect()
+        return disconnectedWas.call(this, ...args)
+    }
+
+    // unmount() scrubs style/class but not other attributes, so a recycled element can
+    // carry collapse state from its previous binding — scrub it on acquire.
+    const acquireRowElementWas = proto.acquireRowElement
+    proto.acquireRowElement = function (...args) {
+        const el = acquireRowElementWas.apply(this, args)
+        el.removeAttribute('collapsed')
+        return el
+    }
+    const acquireCellWas = proto.acquireCell
+    proto.acquireCell = function (...args) {
+        const cell = acquireCellWas.apply(this, args)
+        cell.removeAttribute('collapse-toggle')
+        return cell
+    }
+
+    // Track the window: observe mounted row elements, drop pooled ones. Unobserving on
+    // unmount matters beyond hygiene — it makes the observe() on remount a fresh
+    // observation, whose initial fire runs the recycled element's first check even when
+    // its size didn't change across bindings.
+    const syncMountedWas = proto.syncMounted
+    proto.syncMounted = function (...args) {
+        syncMountedWas.apply(this, args)
+        for (const el of this._rowPool) this.collapseObserver.unobserve(el)
+        for (const row of this.mounted) this.collapseObserver.observe(row.element)
+    }
+
+    // Cells render after the loadRecords batch settles, which may not resize the row
+    // (placeholder and clamped cells can land at the same height) — check explicitly.
+    const renderCellsWas = this.Row.prototype.renderCells
+    this.Row.prototype.renderCells = async function (...args) {
+        await renderCellsWas.apply(this, args)
+        if (this.mounted) this.grid.checkRowCollapse?.(this)
     }
 
     /**
-     * Rebuild `this.rows` from the group structure: every header is visible; a group's
-     * members are visible only while it is expanded. This is the integration point with
-     * virtualization — geometry, windowing, and the scrollbar all consume `this.rows`,
-     * so a collapsed group contributes only its (one) header row to the total height.
+     * Recompute the truncation state of one mounted row: re-apply its persisted
+     * expansion, flag the element `collapsed` when any cell's content is truncated, and
+     * (re)render the expand/collapse toggles. Idempotent — runs on every resize of the
+     * row element, so it always rebuilds from controller state rather than diffing.
      */
-    proto.projectVisibleRows = function () {
-        const out = []
-        for (const group of this._groups.values()) {
-            out.push(group.header)
-            if (!group.header.collapsed) out.push(...group.members)
-        }
-        this.rows = out
-        this.reindexRows(0)
-        // Keep the geometry's element list pointed at the new array, then re-sum.
-        if (this.rowGeometry) {
-            this.rowGeometry.elements = this.rows
-            this.rowGeometry.rebuildFrom(0)
-        }
-    }
-
-    /* -----------------------------------------------------------------
-       Group-header rendering — a header row paints as a single full-width
-       banner instead of per-column cells. We override the row controller's
-       renderCells for header rows; data rows fall through to the original.
-    ----------------------------------------------------------------- */
-    const renderCellsWas = this.Row.prototype.renderCells
-    this.Row.prototype.renderCells = function (...args) {
-        if (!this.isGroupHeader) return renderCellsWas.call(this, ...args)
-        this.grid.renderGroupHeaderCells(this)
-    }
-
-    proto.renderGroupHeaderCells = function (row) {
-        row.cellsByColumn = new Map()
-        const cell = this.acquireCell()
-        // Bind to the first column so pooled-cell bookkeeping (column.cells) stays sane,
-        // then override its layout to span the full row as a banner.
-        const column = this.columns[0]
-        if (column) {
-            cell.bind(row, column, null)
-            column.cells.add(cell)
-            row.cellsByColumn.set(column, cell)
-        } else {
-            cell.row = row
-        }
-        cell.classList.add('group-header')
-        cell.classList.remove('frozen')
-        cell.style.gridColumn = '1 / -1'
-        cell.style.left = ''
-        cell.removeAttribute('role')
-        cell.toggleAttribute('collapsed', !!row.collapsed)
-
-        const label = this.groupHeader
-            ? this.groupHeader(row.groupKey, row.group.members, this)
-            : `${row.groupKey == null ? '' : row.groupKey} (${row.group.members.length})`
-
-        renderContent(cell, {
-            tag: `${this.localName}-group-toggle`,
-            content: [
-                {
-                    tag: 'svg',
-                    xmlns: 'http://www.w3.org/2000/svg',
-                    width: '12', height: '12', viewBox: '0 0 24 24',
-                    fill: 'none', stroke: 'currentColor', 'stroke-width': '3',
-                    'stroke-linecap': 'round', 'stroke-linejoin': 'round',
-                    class: 'caret',
-                    content: { tag: 'polyline', points: '6 9 12 15 18 9' }
-                },
-                { tag: `${this.localName}-group-label`, content: label }
-            ]
+    proto.checkRowCollapse = function (row) {
+        const el = row.element
+        if (!el || !row.cellsByColumn) return
+        el.querySelectorAll(`${this.localName}-collapse-toggle`).forEach(t => t.remove())
+        row.cellsByColumn.forEach(cell => cell.removeAttribute('collapse-toggle'))
+        this.resetRowExpand(row)
+        const overflowing = []
+        row.cellsByColumn.forEach((cell, column) => {
+            if (cell !== row.expandedCell && cell.scrollHeight - cell.clientHeight > 1) {
+                overflowing.push([column, cell])
+            }
         })
-
-        cell.addEventListener('click', () => this.toggleGroup(row.groupKey))
-        row.element.appendChild(cell)
+        el.toggleAttribute('collapsed', overflowing.length > 0)
+        overflowing.forEach(([column, cell]) => this.renderCollapseToggle(row, column, cell, true))
+        if (row.expandedCell) this.renderCollapseToggle(row, row.expandedColumn, row.expandedCell, false)
     }
 
-    /* -----------------------------------------------------------------
-       Toggle — flip the group's collapsed flag, re-project the visible set,
-       rebuild the window so the mounted rows + scrollbar reflect the change.
-    ----------------------------------------------------------------- */
-    /** Collapse or expand a group by its key (no-op if the key is unknown). */
-    proto.toggleGroup = function (key, collapsed) {
-        const group = this._groups && this._groups.get(key)
-        if (!group) return
-        const next = collapsed == null ? !group.header.collapsed : !!collapsed
-        if (next === group.header.collapsed) return
-        group.header.collapsed = next
-
-        // The mounted set may now hold members of a freshly-collapsed group (or be
-        // missing newly-revealed ones) — drop them all and re-window from scratch.
-        for (const r of Array.from(this.mounted)) r.unmount()
-        this.projectVisibleRows()
-        this.updateWindow()
-        this.trigger('groupToggled', { detail: { key, collapsed: next } })
-    }
-
-    /** Collapse every group. */
-    proto.collapseAll = function () { this._setAllCollapsed(true) }
-    /** Expand every group. */
-    proto.expandAll = function () { this._setAllCollapsed(false) }
-    proto._setAllCollapsed = function (state) {
-        if (!this._groups) return
-        let changed = false
-        for (const group of this._groups.values()) {
-            if (group.header.collapsed !== state) { group.header.collapsed = state; changed = true }
+    /**
+     * Re-apply a row's expansion from its controller state: of the columns the user has
+     * expanded, size the row to the tallest one's full content via `--expandTo` (cleared
+     * when nothing is expanded). The live cell is re-resolved on every pass because cell
+     * elements are pooled; a stale column (spliced out) simply resolves to no cell.
+     */
+    proto.resetRowExpand = function (row) {
+        const el = row.element
+        el.style.removeProperty('--expandTo')
+        row.expandedColumns ??= new Set()
+        row.expandedColumn = null
+        row.expandedCell = null
+        for (const column of row.expandedColumns) {
+            const cell = row.cellOf(column)
+            if (cell && (!row.expandedCell || cell.scrollHeight > row.expandedCell.scrollHeight)) {
+                row.expandedColumn = column
+                row.expandedCell = cell
+            }
         }
-        if (!changed) return
-        for (const r of Array.from(this.mounted)) r.unmount()
-        this.projectVisibleRows()
-        this.updateWindow()
+        if (row.expandedCell) {
+            // Measure unclamped so nested max-height content can't under-report.
+            row.expandedCell.style.setProperty('max-height', 'unset')
+            el.style.setProperty('--expandTo', row.expandedCell.scrollHeight + 'px')
+            row.expandedCell.style.removeProperty('max-height')
+        }
     }
 
-    /* -----------------------------------------------------------------
-       Styles — full-width banner + twirl caret for the group header rows.
-    ----------------------------------------------------------------- */
+    proto.renderCollapseToggle = function (row, column, cell, expand = true) {
+        cell.setAttribute('collapse-toggle', expand ? 'expand' : 'collapse')
+        const toggle = createElement(`${this.localName}-collapse-toggle`, {
+            class: cell.classList.contains('frozen') ? 'frozen' : '',
+            style: { 'grid-column': String(column.index + 1) },
+            content: listenerElement({
+                type: 'button',
+                content: `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="8" viewBox="0 0 14 8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="${expand ? 'expand' : 'collapse'}"><polyline points="1 1 7 7 13 1"></polyline></svg>`
+            }, () => {
+                row.expandedColumns ??= new Set()
+                if (expand) {
+                    row.expandedColumns.add(column)
+                } else {
+                    row.expandedColumns.clear()
+                }
+                this.checkRowCollapse(row)
+            })
+        })
+        if (cell.classList.contains('frozen')) toggle.style.left = cell.style.left
+        // Keep the toggle from starting a selection / edit underneath (DataSpreadsheet).
+        toggle.addEventListener('pointerdown', e => e.stopPropagation())
+        toggle.addEventListener('mousedown', e => e.stopPropagation())
+        row.element.prepend(toggle)
+    }
+
     if (!Array.isArray(this.style)) this.style = [this.style]
     this.style.push(function () { return `
-        ${this.tagName}-cell.group-header {
-            grid-column: 1 / -1;
-            position: sticky;
-            left: 0;
+        ${this.tagName} {
+            --collapseTo: auto;
+        }
+        ${this.tagName}-row {
+            max-height: var(--expandTo, var(--collapseTo));
+            overflow: clip;
+        }
+        ${this.tagName}-cell,
+        ${this.tagName}-collapse-toggle {
+            max-height: var(--expandTo, var(--collapseTo));
+        }
+        ${this.tagName}-cell[collapse-toggle] {
+            padding-bottom: 16px;
+        }
+        ${this.tagName}-collapse-toggle {
             display: flex;
-            align-items: center;
-            gap: 6px;
-            box-sizing: border-box;
-            inline-size: var(--dg-width);
-            padding: 4px 8px;
-            font-weight: 600;
-            background: var(--dg-group-header-bg, #f3f4f6);
-            border-block-end: 1px solid var(--dg-group-header-border, #e5e7eb);
-            cursor: pointer;
-            user-select: none;
-            -webkit-user-select: none;
+            flex-direction: column;
+            justify-content: end;
+            text-align: center;
+            grid-row: 1 / -1;
+            z-index: 2;
+            pointer-events: none;
+        }
+        ${this.tagName}-collapse-toggle:hover {
+            color: var(--select-color, #1a73e8);
+        }
+        ${this.tagName}-collapse-toggle:hover svg {
+            opacity: 1;
+        }
+        ${this.tagName}-collapse-toggle.frozen {
+            position: sticky;
             z-index: 6;
         }
-        ${this.tagName}-cell.group-header:hover {
-            background: var(--dg-group-header-bg-hover, #e9eaed);
-        }
-        ${this.tagName}-group-toggle {
-            display: inline-flex;
+        ${this.tagName}-collapse-toggle button {
+            outline: none;
+            appearance: none;
+            border: none;
+            padding: 0;
+            margin: 0;
+            text-decoration: none;
+            color: inherit;
+            pointer-events: auto;
+
+            background: linear-gradient(rgba(255,255,255, 0), rgba(255,255,255, 0.7) 30%, white);
+            cursor: pointer;
+            font-size: 0.8em;
+
+            padding: 5px;
+            display: flex;
+            justify-content: center;
             align-items: center;
-            gap: 6px;
         }
-        ${this.tagName}-group-toggle .caret {
-            flex: none;
-            transition: transform 0.12s ease;
-        }
-        ${this.tagName}-cell.group-header[collapsed] .caret {
-            transform: rotate(-90deg);
-        }
-        ${this.tagName}-group-label {
+        ${this.tagName}-collapse-toggle svg {
             display: inline-block;
+            opacity: 0.5;
+        }
+        ${this.tagName}-collapse-toggle svg.collapse {
+            transform: rotate(180deg)
         }
     `})
 }

--- a/lib/komps/data-grid/plugins/collapsible.js
+++ b/lib/komps/data-grid/plugins/collapsible.js
@@ -198,8 +198,12 @@ export default function (proto) {
             justify-content: end;
             text-align: center;
             grid-row: 1 / -1;
-            z-index: 2;
+            /* Above DataSpreadsheet's active cell (z 3) so the button stays clickable
+               when its cell is selected, but below frozen cells (z 5) so a scrolling
+               toggle still slides under frozen columns. */
+            z-index: 4;
             pointer-events: none;
+            margin-bottom: 1px; /* keep the gradient off the cell's border line */
         }
         ${this.tagName}-collapse-toggle:hover {
             color: var(--select-color, #1a73e8);

--- a/lib/komps/data-grid/plugins/collapsible.js
+++ b/lib/komps/data-grid/plugins/collapsible.js
@@ -58,6 +58,13 @@ export default function (proto) {
                 if (entry.target.row) this.checkRowCollapse(entry.target.row)
             }
         })
+        // Interplay with the resizable plugin (order-independent — listens for its
+        // event): dragging a row edge is the user explicitly setting that row's height,
+        // so it replaces any expansion and becomes the row's clamp (see checkRowCollapse).
+        this.addEventListener('rowResized', e => {
+            e.detail.row.expandedColumns?.clear()
+            this.checkRowCollapse(e.detail.row)
+        })
         return initializeWas.call(this, ...args)
     }
 
@@ -112,6 +119,14 @@ export default function (proto) {
         if (!el || !row.cellsByColumn) return
         el.querySelectorAll(`${this.localName}-collapse-toggle`).forEach(t => t.remove())
         row.cellsByColumn.forEach(cell => cell.removeAttribute('collapse-toggle'))
+        // A manually resized row (resizable plugin) uses its height as the clamp:
+        // publish it as this row's --collapseTo so cells stretch/truncate to the
+        // forced height instead of stopping at the grid-wide budget.
+        if (row._resizedHeight) {
+            el.style.setProperty('--collapseTo', row.height + 'px')
+        } else {
+            el.style.removeProperty('--collapseTo')
+        }
         this.resetRowExpand(row)
         const overflowing = []
         row.cellsByColumn.forEach((cell, column) => {
@@ -163,6 +178,12 @@ export default function (proto) {
                 row.expandedColumns ??= new Set()
                 if (expand) {
                     row.expandedColumns.add(column)
+                    // Expanding means "size to content" — release a manual resize
+                    // (resizable plugin) so the forced height can't pin the row.
+                    if (row._resizedHeight) {
+                        row._resizedHeight = false
+                        row.element.style.height = ''
+                    }
                 } else {
                     row.expandedColumns.clear()
                 }

--- a/lib/komps/data-grid/plugins/collapsible.js
+++ b/lib/komps/data-grid/plugins/collapsible.js
@@ -181,10 +181,10 @@ export default function (proto) {
         ${this.tagName} {
             --collapseTo: auto;
         }
-        ${this.tagName}-row {
-            max-height: var(--expandTo, var(--collapseTo));
-            overflow: clip;
-        }
+        /* The cells do the clamping and clipping (they're overflow: hidden in the core
+           styles), not the row: the row's track then follows the tallest clamped cell,
+           and per-cell decorations at the visible row edge (e.g. border-bottom grid
+           lines) stay inside the cell's own box where nothing can clip them. */
         ${this.tagName}-cell,
         ${this.tagName}-collapse-toggle {
             max-height: var(--expandTo, var(--collapseTo));


### PR DESCRIPTION
## Summary

Adds an opt-in `collapsible` plugin for the **virtualized** `DataGrid` (and subclasses like `DataSpreadsheet`) — the windowed counterpart of the Table `collapsible` plugin, with the same semantics:

- `collapseTo` (any valid CSS size, default `auto`) sets a height budget for rows via `max-height: var(--expandTo, var(--collapseTo))`.
- Rows whose cell content overflows are truncated and flagged with a `collapsed` attribute; each overflowing cell gets a gradient chevron toggle (same affordance as Table's).
- Clicking expand sizes the row to that cell's full content by setting `--expandTo` on the row element; the collapse toggle reverses it.

Like the sibling `resizable`/`reorderable` DataGrid plugins, it is not auto-included — consumers opt in with `DataGrid.include(collapsible)` / `DataSpreadsheet.include(collapsible)`.

## Virtualization integration

The tricky part is that DataGrid pools/recycles row and cell elements and drives windowing off measured heights. The plugin leans on the existing pipeline instead of adding geometry code:

- **Clamping is pure CSS**, so the grid's normal measure pass records the clamped height; expanding (`--expandTo`) resizes the element, which the grid's own row ResizeObserver already turns into `measure()` → `reflow()` — offsets, the mounted window, and the body scroll extent update for free.
- **Expanded state lives on the persistent `DataGridRow` controller** (`row.expandedColumns`, a Set of columns), never on pooled elements. The live cell is re-resolved on every pass via `row.cellOf(column)`, and measured heights already travel with controllers — so an expanded row scrolled out of the window keeps its height and restores its expansion (and toggles) when it scrolls back in, and expansion survives `sortRows`/splices.
- A plugin ResizeObserver watches mounted row elements (observe on mount, unobserve when pooled — re-observation gives each mount a free initial check). The check (`checkRowCollapse`) is idempotent: it always rebuilds toggles/attributes from controller state, so it can run on every resize (content rendering in, column resize rewrapping text, `--expandTo` changing).
- Pooled elements are scrubbed of `collapsed` / `collapse-toggle` attributes on acquire, since `unmount()` only clears style/class.
- Toggles for frozen columns get `position: sticky` + the cell's `left`; toggle pointerdown/mousedown are stopped so clicking one doesn't start a DataSpreadsheet selection.

## Verified

Drove the `data-spreadsheet` demo (872 rows, `collapseTo: '60px'`, multi-line Awards column) headlessly: truncation + toggles on load; expand grows the row 60→192px with the body scroll height growing by exactly the delta; scroll-away-and-back restores expansion on the recycled element; collapse reverts; column resize re-checks truncation; `sortRows` keeps expanded heights with their rows; toggle clicks don't trigger selection; no console/ResizeObserver errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)