### PR TITLE
Fix missing brace in reorderable placement-indicator.column rule

### DIFF
--- a/lib/komps/data-grid/plugins/reorderable.js
+++ b/lib/komps/data-grid/plugins/reorderable.js
@@ -374,7 +374,7 @@ export default function (proto) {
             z-index: 2;
             inline-size: 2px;
         }
-        ${this.tagName}-placement-indicator.column 
+        ${this.tagName}-placement-indicator.column {
             transform: translateX(-1px);
         }
         ${this.tagName}-placement-indicator.row {


### PR DESCRIPTION
## Summary

`lib/komps/data-grid/plugins/reorderable.js` was missing the opening `{` on the `${tagName}-placement-indicator.column` rule:

```css
${this.tagName}-placement-indicator.column      /* ← no { */
    transform: translateX(-1px);
}
```

Component styles are injected wrapped in `@layer ${styleLayer} { … }` (`KompElement.renderStyle`). With the brace missing, the parser swallows the `}` meant to close `.column` while looking for the block start — which **closes the `@layer komps` block early**. Every rule after it (the `komp-data-grid` / `komp-data-spreadsheet` base rules, the resizable styles, etc.) leaks out of the layer, so a reorderable grid's styles aren't layered at all.

## Fix
Add the missing `{`.

## Verification
Confirmed against the live DataSpreadsheet sheet: before the fix the `@layer komps` block closed right after `…-placement-indicator` and the `komp-data-spreadsheet` base rule (and everything after) was a top-level (unlayered) rule. Minimal CSSOM repro:

- broken `.column` (no brace) → `x-placement-indicator.row` and `x-base` leak out of `@layer`
- with the brace → nothing leaks

Bug originated in the reorderable plugin (#54).

🤖 Generated with [Claude Code](https://claude.com/claude-code)