### PR TITLE
DataSpreadsheet: fix editor floater min-width dropping for string column widths

### DIFF
--- a/lib/komps/data-spreadsheet.js
+++ b/lib/komps/data-spreadsheet.js
@@ -366,8 +366,11 @@ export default class DataSpreadsheet extends DataGrid {
             removeOnBlur: true,
             offset: ({ rects }) => ({ mainAxis: -rects.reference.height }),
             style: {
-                '--cell-width': cell.column.width + "px",
-                '--cell-height': cell.row.height + "px"
+                // Resolved px from geometry (numbers), not the raw config: column.width
+                // may be a CSS px string ("200px" + "px" → "200pxpx") and row.height is
+                // null until measured — either would yield an invalid length and drop the rule.
+                '--cell-width': this.columnGeometry.sizeAt(column.index) + "px",
+                '--cell-height': this.rowGeometry.sizeAt(cell.rowIndex) + "px"
             },
             onHidden: e => {
                 cell.tabIndex = 0


### PR DESCRIPTION
## Problem

`activateCell` seeds the editor floater's `--cell-width` CSS variable from `cell.column.width + "px"`. But `column.width` is documented as `number | string` (a CSS px string is allowed), so a string-configured width like `"200px"` yields `"200pxpx"` — an invalid length. The browser drops the `min-width: var(--cell-width)` rule on `.{tag}-input > label`, and the editor falls back to `min-width: auto` instead of matching the cell.

`--cell-height` had the analogous latent issue: it used `cell.row.height`, which is `null` until the row is measured (`"nullpx"`).

## Fix

Source both variables from the geometry layer, which returns resolved, cached **numbers** in px (it already normalizes the `number|string` config and the default via `resolveWidth`):

```js
'--cell-width': this.columnGeometry.sizeAt(column.index) + "px",
'--cell-height': this.rowGeometry.sizeAt(cell.rowIndex) + "px"
```

This also brings it closer to the non-virtualized `Spreadsheet`, which measures the live `offsetWidth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)