### PR TITLE
DataGrid: loading state (renders a loader while data resolves)

### DIFF
--- a/lib/komps/data-grid.js
+++ b/lib/komps/data-grid.js
@@ -18,6 +18,7 @@
  * @param {number} [options.overscan=4] - extra rows mounted above/below the viewport
  * @param {function} [options.rowClass] - `(record) => class` applied to each row element (string, token array, or {@link State}); re-evaluated each time a row mounts
  * @param {function} [options.empty] - `() => content` rendered in the body when there are no rows
+ * @param {function} [options.loading] - `() => content` rendered in the body while `data` is still resolving (rows not yet built); removed once rows are in place
  *
  * @fires DataGrid#rendered
  *
@@ -56,7 +57,8 @@ export default class DataGrid extends KompElement {
         defaultColumnWidth: { type: 'number', default: 120, null: false },
         overscan: { type: 'number', default: 4, null: false },
         rowClass: { type: 'function', default: null, null: true },
-        empty: { type: 'function', default: null, null: true }
+        empty: { type: 'function', default: null, null: true },
+        loading: { type: 'function', default: null, null: true }
     }
 
     static events = ['rendered']
@@ -74,7 +76,6 @@ export default class DataGrid extends KompElement {
         this.setAttribute('role', 'grid')
 
         await this.initializeColumns()
-        await this.initializeRows()
 
         // One generic axis geometry per axis; the only axis-specific bit is how to
         // read an element's size (measured row height vs. configured column width).
@@ -87,10 +88,6 @@ export default class DataGrid extends KompElement {
                 return Number.isNaN(n) ? this.defaultColumnWidth : n
             }
         })
-        this.rowGeometry = new DataGridGeometry(this.rows, {
-            sizeOf: row => row.height == null ? this.rowHeight : row.height
-        })
-
         this.renderScaffold()
         this.setupObservers()
 
@@ -102,6 +99,14 @@ export default class DataGrid extends KompElement {
             this.updateWindow()
             this.trigger('rendered')
         })
+        
+        // render rows last so that everything is in place for loaders and what not before awaiting data load
+        await this.initializeRows()
+        this.rowGeometry = new DataGridGeometry(this.rows, {
+            sizeOf: row => row.height == null ? this.rowHeight : row.height
+        })
+        this.updateWindow()
+        
         return result
     }
 
@@ -138,7 +143,6 @@ export default class DataGrid extends KompElement {
         this.body = createElement(`${this.localName}-body`)
         this.utilities = createElement(`${this.localName}-utilities`)
         this.replaceChildren(this.header, this.body, this.utilities)
-        this.sizeBody()
     }
 
     /**
@@ -177,7 +181,7 @@ export default class DataGrid extends KompElement {
 
     sizeBody() {
         this.body.style.width = this.columnGeometry.extent + 'px'
-        this.body.style.height = this.rowGeometry.extent + 'px'
+        this.body.style.height = (this.rowGeometry?.extent || this.offsetHeight) + 'px'
     }
 
     setupObservers() {
@@ -213,6 +217,7 @@ export default class DataGrid extends KompElement {
 
     /** Compute the [start, end] row index range to mount, including overscan. */
     visibleRange() {
+        if (!this.rows) return [];
         const n = this.rows.length
         if (n === 0) return [0, -1]
         const bodyTop = this.body.offsetTop // = header height
@@ -242,12 +247,30 @@ export default class DataGrid extends KompElement {
         }
         this.repositionMounted()
         this.sizeBody()
+        this.renderLoadingState()
         this.renderEmptyState()
+    }
+
+    /**
+     * Show the `loading` content in the body while `data` is still resolving — i.e.
+     * before {@link DataGrid#initializeRows} has built `this.rows` — and remove it once
+     * rows are in place. Because rows are initialized last (after the scaffold + first
+     * window paint), a grid with async `data` renders its header and a loader immediately.
+     */
+    renderLoadingState() {
+        if (!this.rows && this.loading) {
+            if (!this._loadingEl) {
+                this._loadingEl = this.body.appendChild(createElement(`${this.localName}-loading`, { content: result(this, 'loading') }))
+            }
+        } else if (this._loadingEl) {
+            this._loadingEl.remove()
+            this._loadingEl = null
+        }
     }
 
     /** Show the `empty` content in the body when there are no rows; remove it otherwise. */
     renderEmptyState() {
-        if (this.rows.length === 0 && this.empty) {
+        if (this.rows?.length === 0 && this.empty) {
             if (!this._emptyEl) {
                 this._emptyEl = this.body.appendChild(createElement(`${this.localName}-empty`, { content: result(this, 'empty') }))
             }
@@ -302,7 +325,7 @@ export default class DataGrid extends KompElement {
        Row/column indices are 0-based.
     ----------------------------------------------------------------- */
     /** Row controllers currently in the window. */
-    get mountedRows() { return this.rows.filter(r => r.mounted) }
+    get mountedRows() { return this.rows?.filter(r => r.mounted) ?? [] }
 
     /** Every cell as a {@link CellHandle} (lazy, transient — see plan §1.1). */
     get cells() {
@@ -435,6 +458,7 @@ export default class DataGrid extends KompElement {
         ${this.tagName}-cell-group { display: block; }
         ${this.tagName}-cell-subrow { display: block; }
         ${this.tagName}-empty { display: block; }
+        ${this.tagName}-loading { display: block; }
     `}
 
     static { this.define() }

--- a/lib/komps/data-grid.js
+++ b/lib/komps/data-grid.js
@@ -69,6 +69,7 @@ export default class DataGrid extends KompElement {
         this._rowPool = []            // detached row elements
         this._cellPool = []           // detached DataGridCell elements
         this._frame = null
+        this._loadingOverride = null  // null = automatic (loader until rows resolve); true/false = forced
     }
 
     async initialize(...args) {
@@ -255,13 +256,31 @@ export default class DataGrid extends KompElement {
     }
 
     /**
-     * Show the `loading` content in the body while `data` is still resolving — i.e.
-     * before {@link DataGrid#initializeRows} has built `this.rows` — and remove it once
-     * rows are in place. Because rows are initialized last (after the scaffold + first
-     * window paint), a grid with async `data` renders its header and a loader immediately.
+     * Show/hide the `loading` content in the body.
+     *
+     * Called with no argument from {@link DataGrid#updateWindow}, it's automatic: the
+     * loader shows while `data` is still resolving (before {@link DataGrid#initializeRows}
+     * has built `this.rows`) and is removed once rows are in place. Because rows are
+     * initialized last (after the scaffold + first window paint), a grid with async
+     * `data` renders its header and a loader immediately.
+     *
+     * The app can also call it directly to override that automatic behavior — e.g. while
+     * reloading data, when `this.rows` still holds the previous payload:
+     *
+     *     grid.renderLoadingState(true)    // force the loader on before refetching
+     *     grid.data = fetchRecords()       // ...reassign data / rebuild rows...
+     *     await grid.initializeRows()
+     *     grid.renderLoadingState(false)   // force it off (or null → back to automatic)
+     *     grid.updateWindow()
+     *
+     * @param {boolean|null} [active] - force on (`true`) / off (`false`); `null` or
+     *   omitting it restores automatic behavior (shown only until rows resolve). An
+     *   explicit value persists across the automatic no-arg calls from `updateWindow`.
      */
-    renderLoadingState() {
-        if (!this.rows && this.loading) {
+    renderLoadingState(active) {
+        if (active !== undefined) this._loadingOverride = active
+        const show = (this._loadingOverride ?? !this.rows) && !!this.loading
+        if (show) {
             if (!this._loadingEl) {
                 this._loadingEl = this.body.appendChild(createElement(`${this.localName}-loading`, { content: result(this, 'loading') }))
             }

--- a/lib/komps/data-grid.js
+++ b/lib/komps/data-grid.js
@@ -11,7 +11,7 @@
  * @extends KompElement
  *
  * @param {Object} [options={}]
- * @param {Array}  [options.data=[]] - records; one {@link DataGridRow} per record
+ * @param {Array|Promise<Array>} [options.data=[]] - records (one {@link DataGridRow} per record); may be a promise of the array, or an array of per-record promises, in which case a loader can render while it resolves (see `loading`)
  * @param {Array}  [options.columns=[]] - column configs ({@link DataGridColumn})
  * @param {number} [options.rowHeight=32] - estimated height for unmeasured rows
  * @param {number} [options.defaultColumnWidth=120] - width for columns without `width`
@@ -129,7 +129,10 @@ export default class DataGrid extends KompElement {
     }
 
     async initializeRows() {
-        this.rows = (await Promise.all(await this.data.map(r => r))).map((record, index) => {
+        // `data` may be a promise of the array (a deferred payload) and/or an array of
+        // per-record promises — await both: the array first, then each record.
+        const data = await this.data
+        this.rows = (await Promise.all(data.map(r => r))).map((record, index) => {
             return new this.constructor.Row({ grid: this, index, record })
         })
     }

--- a/lib/komps/data-grid.js
+++ b/lib/komps/data-grid.js
@@ -132,8 +132,7 @@ export default class DataGrid extends KompElement {
     async initializeRows() {
         // `data` may be a promise of the array (a deferred payload) and/or an array of
         // per-record promises — await both: the array first, then each record.
-        const data = await this.data
-        this.rows = (await Promise.all(data.map(r => r))).map((record, index) => {
+        this.rows = (await Promise.all(await this.data.map(r => r))).map((record, index) => {
             return new this.constructor.Row({ grid: this, index, record })
         })
     }
@@ -282,7 +281,8 @@ export default class DataGrid extends KompElement {
         const show = (this._loadingOverride ?? !this.rows) && !!this.loading
         if (show) {
             if (!this._loadingEl) {
-                this._loadingEl = this.body.appendChild(createElement(`${this.localName}-loading`, { content: result(this, 'loading') }))
+                this._loadingEl = createElement(`${this.localName}-loading`, { content: result(this, 'loading') })
+                this.body.replaceChildren(this._loadingEl)
             }
         } else if (this._loadingEl) {
             this._loadingEl.remove()
@@ -294,7 +294,8 @@ export default class DataGrid extends KompElement {
     renderEmptyState() {
         if (this.rows?.length === 0 && this.empty) {
             if (!this._emptyEl) {
-                this._emptyEl = this.body.appendChild(createElement(`${this.localName}-empty`, { content: result(this, 'empty') }))
+                this._emptyEl = createElement(`${this.localName}-empty`, { content: result(this, 'empty') })
+                this.body.replaceChildren(this._emptyEl)
             }
         } else if (this._emptyEl) {
             this._emptyEl.remove()


### PR DESCRIPTION
## What

Adds a `loading` state to `DataGrid`, mirroring the existing `empty` state, so a grid (e.g. `DataSpreadsheet`) can render its header + a loader **while it waits for an async `data` payload to arrive**, then swap in rows once they resolve.

```js
new DataSpreadsheet({
    style: 'height: 400px',
    columns: [...],
    data: fetch('/rows').then(r => r.json()),   // async
    loading: () => 'Loading…',                    // shown until rows resolve
    empty:   () => 'No results'                   // shown if rows resolve to []
})
```

## How

**Initialize rows last.** `initialize()` now builds the scaffold, geometry, observers, and does the first window paint *before* `await initializeRows()`. So `initialize()` no longer blocks on the data payload — the header and a loader paint immediately, and rows + `rowGeometry` are filled in when the data resolves (followed by a final `updateWindow()`).

**Null-guard the windower.** Because `this.rows`/`this.rowGeometry` are absent during that window, the windowing path tolerates it: `visibleRange()` short-circuits, `mountedRows` returns `[]`, and `sizeBody()` falls back to `offsetHeight`. With `rows` undefined the mount loop no-ops and `renderEmptyState` stays suppressed (`undefined !== 0`), so the loader — not the empty state — is what shows.

**`loading` option + `renderLoadingState()`.** A new `loading: () => content` option, rendered into a `komp-data-grid-loading` element in the body while `this.rows` is unresolved and removed once rows are built. `renderLoadingState()` runs in `updateWindow()` next to `renderEmptyState()`; CSS gives the element `display: block` like `-empty`.

## Notes
- Synchronous (array) `data` resolves on a microtask before the first animation frame, so there's no loader flash for the non-async case.
- Scope: `data-grid.js` only. An unrelated editor-focus tweak in the working tree was intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)