### PR TITLE
DataSpreadsheet: swallow the opening Enter's keyup

### DIFF
--- a/lib/komps/data-spreadsheet.js
+++ b/lib/komps/data-spreadsheet.js
@@ -117,6 +117,13 @@ export default class DataSpreadsheet extends DataGrid {
             } else if (key === 'Enter') {
                 e.preventDefault()
                 this.activateCell(cell)
+                // The same Enter press fires a keyup on the editor we just focused; swallow it
+                // (once, in capture so it beats the editor's own listener) so it can't drive
+                // editor behavior — e.g. a SearchField selecting its first result on keyup and
+                // instantly closing the cell we just opened.
+                this.getRootNode().addEventListener('keyup', ev => {
+                    if (ev.key === 'Enter') { ev.stopImmediatePropagation(); ev.preventDefault() }
+                }, { once: true, capture: true })
             } else if (key === 'Tab') {
                 e.preventDefault()
                 this.moveActive(e.shiftKey ? 'left' : 'right')


### PR DESCRIPTION
## Problem

Opening a cell with **Enter** flashes the editor open and immediately closes it (double-click is fine). Most visible on a `belongs_to` column with `defaultResults` (e.g. an Owner column).

## Cause

Enter fires `keydown` → `activateCell` opens the floater and focuses the editor input. Because focus moved to the input *during* the keydown, the subsequent **keyup** (on release) lands on the now-focused editor. `SearchField._keyup` selects its first result on Enter when results are shown — and `defaultResults` are shown on focus — so the opening Enter's keyup auto-selects the first result → commit → `moveActive('down')` → the just-opened cell closes (and the value is silently set).

Deferring focus (rAF) doesn't help: a human Enter tap (~50–150ms) outlasts the frame, so the input is focused when the keyup lands.

## Fix

Swallow the opening Enter's keyup — a one-shot capture-phase listener (so it beats the editor's own keyup) that consumes the next Enter keyup. The keystroke that opens a cell can no longer leak into the editor; Enter pressed while editing is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)