### PR TITLE
DataSpreadsheet CheckboxColumn: bind via Input.create

### DIFF
--- a/lib/komps/data-spreadsheet/columns/checkbox-column.js
+++ b/lib/komps/data-spreadsheet/columns/checkbox-column.js
@@ -1,14 +1,24 @@
 /**
- * Boolean column for {@link DataSpreadsheet}. Renders a checkbox reflecting the
- * value; activating the cell (click / Enter / type) toggles it inline instead of
- * opening a floating editor.
+ * Boolean column for {@link DataSpreadsheet}. Renders a **bound** checkbox (via
+ * {@link Input}) reflecting the value; activating the cell (click / Enter / type) toggles
+ * it inline instead of opening a floating editor.
+ *
+ * Binding through {@link Input} (rather than a static checkbox) means the column works for a
+ * plain boolean attribute *and* for any value the binding understands — e.g. a record whose
+ * attribute is a reactive State: the bound checkbox reads it via `== true` (coercing the
+ * State by `valueOf`), writes through the record's setter, and reflects external changes
+ * reactively.
  *
  * @class CheckboxColumn
  * @extends DataSpreadsheetColumn
  */
 import DataSpreadsheetColumn from '../column.js'
+import Input from '../../input.js'
 
 export default class CheckboxColumn extends DataSpreadsheetColumn {
+    /** Input kind passed to `Input.create`. */
+    static inputType = 'checkbox'
+
     constructor(options = {}) {
         super(options)
         this.toggleable = true
@@ -16,19 +26,31 @@ export default class CheckboxColumn extends DataSpreadsheetColumn {
     }
 
     renderContent(record) {
-        return { tag: 'input', type: 'checkbox', checked: !!(record && record[this.attribute]), tabindex: '-1' }
+        return Input.create(this.constructor.inputType, Object.assign({
+            target: record,
+            attribute: this.attribute,
+            tabindex: -1
+        }, this.inputOptions))
     }
 
-    valueFor(record) { return record && record[this.attribute] ? 'true' : 'false' }
+    valueFor(record) { return record?.[this.attribute] == true ? 'true' : 'false' }
 
     parsePaste(value) {
         return value === true || value === 'true' || value === '1' || value === 1
     }
 
-    /** Flip the record's boolean — called by the grid on activate (toggleable). */
+    clear(record) {
+        if (this.attribute != null) record[this.attribute] = false
+    }
+
+    /**
+     * Flip the value on activate (toggleable). Reads via `== true` so a bound value (e.g. a
+     * State, whose getter returns the object) coerces by `valueOf` rather than reading as a
+     * truthy object; the assignment routes through the record's setter.
+     */
     toggle(record) {
         if (this.editable && this.attribute != null) {
-            record[this.attribute] = !record[this.attribute]
+            record[this.attribute] = !(record[this.attribute] == true)
         }
     }
 


### PR DESCRIPTION
## Summary

`CheckboxColumn` rendered a static `{ tag: 'input', checked: !!record[attr] }` and toggled with `record[attr] = !record[attr]`. That only works when the attribute is a raw boolean.

If a record exposes the attribute as a reactive **State** (getter returns the State object, setter routes to `.set()` — a common pattern), this breaks:
- `!!State` is always truthy → **every checkbox renders checked**
- `record[attr] = !record[attr]` → `!State` is always `false`, and the assignment overwrites the State binding → toggling does nothing useful and the State's listeners never fire
- no reactivity to external changes

## Fix

Render through a bound `Input.create('checkbox', { target, attribute })` (the `BinaryInput`), and read the value with `== true` in `valueFor`/`toggle`. The bound checkbox:
- **reads** via `value == inputValue` → a State coerces correctly by `valueOf` (no all-checked)
- **writes** via the record's setter (`bury` → `record[attr] = bool`), which a State routes through `.set()` (listeners fire)
- **reflects external changes** reactively (Input subscribes to the record's `change`)

Plain-boolean columns are unchanged in behavior. (This mirrors how the non-virtualized `Spreadsheet` checkbox already bound via `Input.create`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)