### PR TITLE
Add spliceColumns/addColumn/removeColumn to DataGrid

### DIFF
--- a/lib/komps/data-grid.js
+++ b/lib/komps/data-grid.js
@@ -442,6 +442,42 @@ export default class DataGrid extends KompElement {
     appendRow(index, ...records) { return this.spliceRows(index, 0, ...records) }
     removeRow(index, count = 1) { return this.spliceRows(index, count) }
 
+    reindexColumns(from = 0) {
+        for (let i = from; i < this.columns.length; i++) this.columns[i].index = i
+    }
+
+    /**
+     * Splice the column set in place (Array#splice semantics over `this.columns`), then
+     * rebuild the dependent structure: column indices, column geometry, the published
+     * `--dg-*` custom properties, and the header. Mounted rows are bound to the previous
+     * columns by index, so the window is torn down and rebuilt — recycled cells re-bind
+     * to the new column set on the next `updateWindow`.
+     *
+     * @param {number} index - 0-based position to start at
+     * @param {number} [deleteCount=0] - columns to remove at `index`
+     * @param {...(Object|DataGridColumn)} newConfigs - column configs (or controllers) to insert
+     * @returns {DataGridColumn[]} the inserted column controllers
+     */
+    spliceColumns(index, deleteCount = 0, ...newConfigs) {
+        const created = newConfigs.map((config, i) => this.buildColumn(config, index + i))
+        this.columns.splice(index, deleteCount, ...created)
+        this.reindexColumns(index)
+        this.columnGeometry.rebuildFrom(index)
+        this.applyColumnGeometry()
+
+        // Header cells are placed by column index — rebuild the header for the new set.
+        const header = this.renderHeader()
+        this.header.replaceWith(header)
+        this.header = header
+
+        // Mounted cells reference the old columns/indices — drop the window and rebuild.
+        for (const row of Array.from(this.mounted)) row.unmount()
+        this.updateWindow()
+        return created
+    }
+    addColumn(index, ...configs) { return this.spliceColumns(index, 0, ...configs) }
+    removeColumn(index, count = 1) { return this.spliceColumns(index, count) }
+
     /* -----------------------------------------------------------------
        Styles
     ----------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

Adds instance methods for mutating a `DataGrid`'s columns at runtime, mirroring the existing row mutation API (`spliceRows`/`appendRow`/`removeRow`):

- `spliceColumns(index, deleteCount = 0, ...newConfigs)` — `Array#splice` semantics over `this.columns`; returns the inserted column controllers
- `addColumn(index, ...configs)` — insert without removing
- `removeColumn(index, count = 1)` — remove without inserting

Also adds `reindexColumns(from)` to keep `column.index` in sync, paralleling `reindexRows`.

## How it works

`spliceColumns` builds new column controllers via the existing `buildColumn` (so it accepts plain configs or `DataGridColumn` instances, and honors `columnTypeRegistry`), splices `this.columns` in place (the same array `columnGeometry` holds), then rebuilds the dependent structure:

- re-indexes columns from the splice point
- `columnGeometry.rebuildFrom(index)` + `applyColumnGeometry()` to refresh the `--dg-template-columns` / `--dg-width` custom properties
- rebuilds the header (header cells are placed by column index)
- tears down the mounted window and calls `updateWindow()` so recycled cells re-bind to the new column set — the same approach `sortRows` uses

## Test plan

No test suite in the repo yet. Verified `node --check` passes; logic follows the established row-mutation pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)