### PR TITLE
consolidate cell activation into DataSpreadsheet.focusCellAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Row-level readonly** — `TableRow` accepts a `readonly` function (called with the record) and a new `renderCell(column, record, options)` method that resolves it per-record before delegating to `column.renderCell`. `Spreadsheet` exposes a matching `readonly` attribute and forwards it to each row, so a single `readonly: record => record.archived` declaration makes all cells in matching rows non-editable. `Table.renderRow` now accepts an optional `attrs` object that is spread into the row's construction options (#28).
 - **SearchField default results** — `SearchField` accepts a `defaultResults` option (Array or async function) shown when the query is below `minLength`, including on focus before the user has typed. Items have the same shape as those returned from `search`, so `result` and `select` apply unchanged. Async functions are resolved once and cached on the instance.
+- **DataSpreadsheet programmatic focus** — `DataSpreadsheet.focusCellAt(col, row)` is now the public entry point for focusing a cell: it makes the cell active, collapses the selection onto it (clearing any copy marquee), scrolls it into view, focuses it, and returns the cell element. Previously this sequence was inlined across the `mousedown`, contextmenu, and arrow/Tab paths. The argument order matches `DataGrid.at(col, row)`.
 
 ### Bug Fixes
 

--- a/lib/komps/data-spreadsheet.js
+++ b/lib/komps/data-spreadsheet.js
@@ -79,7 +79,7 @@ export default class DataSpreadsheet extends DataGrid {
                 cell.focus({ preventScroll: true })
             } else {
                 // Plain click collapses the selection onto the clicked cell.
-                this.focusCellAt(pos.row, pos.col)
+                this.focusCellAt(pos.col, pos.row)
             }
     
             // Drag moves the cursor (range edge) from the active cell, which stays put.
@@ -147,7 +147,7 @@ export default class DataSpreadsheet extends DataGrid {
             const r = this.range()
             const inSel = !!r && pos.row >= r.r0 && pos.row <= r.r1 && pos.col >= r.c0 && pos.col <= r.c1
             if (!inSel) {
-                this.focusCellAt(pos.row, pos.col)
+                this.focusCellAt(pos.col, pos.row)
             }
             this.activateContextMenu(e)
         })
@@ -275,7 +275,7 @@ export default class DataSpreadsheet extends DataGrid {
             const from = this.active || (this.selection && this.selection.focus)
             if (!from) return
             const { row, col } = this.stepFrom(from, dir)
-            this.focusCellAt(row, col)
+            this.focusCellAt(col, row)
         }
     }
 
@@ -293,16 +293,16 @@ export default class DataSpreadsheet extends DataGrid {
     }
 
     /**
-     * Make (row, col) the active cell: collapse the selection onto it, scroll it
+     * Make (col, row) the active cell: collapse the selection onto it, scroll it
      * into view, and move focus to it — the programmatic equivalent of a plain
      * left-click, and the shared path behind a click, an un-extended arrow/Tab
-     * move, and a right-click collapse.
+     * move, and a right-click collapse. Argument order matches {@link DataGrid#at}.
      *
-     * @param {number} row - Row index (0-based)
      * @param {number} col - Column index (0-based)
+     * @param {number} row - Row index (0-based)
      * @returns {DataSpreadsheetCell|null} the focused cell, if currently mounted
      */
-    focusCellAt(row, col) {
+    focusCellAt(col, row) {
         this.active = { row, col }
         this.cursor = { row, col }
         this.setSelection({ row, col }) // collapse the range; clears the copy marquee

--- a/lib/komps/data-spreadsheet.js
+++ b/lib/komps/data-spreadsheet.js
@@ -76,12 +76,11 @@ export default class DataSpreadsheet extends DataGrid {
                 // Shift-click extends the range from the active cell, which stays.
                 this.cursor = pos
                 this.setSelection(this.active, pos)
+                cell.focus({ preventScroll: true })
             } else {
-                this.active = pos
-                this.cursor = pos
-                this.setSelection(pos) // setSelection clears the copy marquee
+                // Plain click collapses the selection onto the clicked cell.
+                this.focusCellAt(pos.row, pos.col)
             }
-            cell.focus({ preventScroll: true })
     
             // Drag moves the cursor (range edge) from the active cell, which stays put.
             const move = ev => {
@@ -148,10 +147,7 @@ export default class DataSpreadsheet extends DataGrid {
             const r = this.range()
             const inSel = !!r && pos.row >= r.r0 && pos.row <= r.r1 && pos.col >= r.c0 && pos.col <= r.c1
             if (!inSel) {
-                this.active = pos
-                this.cursor = pos
-                this.setSelection(pos)
-                cell.focus({ preventScroll: true })
+                this.focusCellAt(pos.row, pos.col)
             }
             this.activateContextMenu(e)
         })
@@ -279,9 +275,6 @@ export default class DataSpreadsheet extends DataGrid {
             const from = this.active || (this.selection && this.selection.focus)
             if (!from) return
             const { row, col } = this.stepFrom(from, dir)
-            this.active = { row, col }
-            this.cursor = { row, col }
-            this.setSelection({ row, col }) // setSelection clears the copy marquee
             this.focusCellAt(row, col)
         }
     }
@@ -299,7 +292,20 @@ export default class DataSpreadsheet extends DataGrid {
         }
     }
 
+    /**
+     * Make (row, col) the active cell: collapse the selection onto it, scroll it
+     * into view, and move focus to it — the programmatic equivalent of a plain
+     * left-click, and the shared path behind a click, an un-extended arrow/Tab
+     * move, and a right-click collapse.
+     *
+     * @param {number} row - Row index (0-based)
+     * @param {number} col - Column index (0-based)
+     * @returns {DataSpreadsheetCell|null} the focused cell, if currently mounted
+     */
     focusCellAt(row, col) {
+        this.active = { row, col }
+        this.cursor = { row, col }
+        this.setSelection({ row, col }) // collapse the range; clears the copy marquee
         this.scrollCellIntoView(row, col)
         let cell = this.cellElementAt(row, col)
         // Single-step moves land within overscan, so the cell is already mounted.
@@ -310,6 +316,7 @@ export default class DataSpreadsheet extends DataGrid {
             cell = this.cellElementAt(row, col)
         }
         if (cell) cell.focus({ preventScroll: true })
+        return cell
     }
 
     frozenWidth() {


### PR DESCRIPTION
## What

Consolidates the "activate a single cell" behavior that was inlined in `DataSpreadsheet`'s `mousedown` handler into `focusCellAt`, which becomes the single programmatic entry point for focusing a cell.

`focusCellAt` was already the shared scroll+focus helper, but every caller — the plain-click branch of `mousedown`, the contextmenu collapse, and `moveActive`'s non-extending branch — prefixed it with the same `active = cursor = pos; setSelection(pos)` prelude. That prelude now lives **inside** `focusCellAt`, so it owns the whole operation:

- set `active`/`cursor`
- collapse the selection onto the cell (clearing any copy marquee)
- scroll it into view
- move focus to it, returning the cell element

The three call sites collapse to a single `focusCellAt(col, row)`.

```js
spreadsheet.focusCellAt(2, 5) // activate + focus the cell at column 2, row 5
```

The argument order is `(col, row)` to match `DataGrid.at(col, row)`.

### No public `focus(col, row)`

An earlier revision added a `focus(col, row)` wrapper, but that shadows the native `HTMLElement.focus`, so it was dropped. `focusCellAt(col, row)` is the programmatic entry point.

The shift-click and `moveActive` *extend* branches — which must keep the active cell put and not collapse the selection — are untouched.

## Notes
- Targets `DataSpreadsheet` (the virtualized, active implementation) where the behavior was buried. Happy to mirror an equivalent onto the legacy `Spreadsheet` if wanted.
- CHANGELOG updated under Unreleased → New Features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)