### PR TITLE
Spreadsheet: replace editor <label> wrapper with a plain frame

### DIFF
--- a/lib/komps/spreadsheet.js
+++ b/lib/komps/spreadsheet.js
@@ -47,6 +47,10 @@ export default class Spreadsheet extends DataGrid {
 
     static events = ['invalidPaste', 'cellChanged']
 
+    /** Focusable controls an editor may expose — used to find the control to focus and to
+     *  tell a click on a real control apart from a stray click on the editor frame. */
+    static editorFocusableSelector = 'input, textarea, select, button, [contenteditable=""], [contenteditable=true], [tabindex], komp-content-area, komp-select'
+
     constructor(...args) {
         super(...args)
         this.selection = null        // { anchor:{row,col}, focus:{row,col} } | null
@@ -405,7 +409,11 @@ export default class Spreadsheet extends DataGrid {
             class: `${this.localName}-input`,
             anchor: cell,
             container: this.utilities, // grid-level layer above the header/frozen z-stack
-            content: { tag: 'label', content: input, class: column.class },
+            // A plain frame, not a <label>: a <label> catches stray clicks in the box's
+            // padding/gutter and redirects them — but it always activates its *first*
+            // labelable control, which fires the wrong button when an editor has several
+            // inputs/buttons. Stray clicks are instead redirected below (floater mousedown).
+            content: { tag: 'div', content: input, class: `${this.localName}-input-frame ${column.class ?? ''}`.trim() },
             placement: 'bottom-start',
             autoPlacement: { alignment: 'start', allowedPlacements: ['top', 'bottom'] },
             removeOnBlur: true,
@@ -450,6 +458,20 @@ export default class Spreadsheet extends DataGrid {
             }
         })
 
+        // Stray clicks on the editor frame (the padding/gutter around the controls) must
+        // not blur the editor. This replaces the old <label> wrapper, which redirected such
+        // clicks but always activated its *first* labelable control — wrong when the editor
+        // has several inputs/buttons. Redirect focus to the intended control ([autofocus] or
+        // the first focusable) without activating anything; clicks on a real control fall
+        // through to their native handling.
+        floater.addEventListener('mousedown', e => {
+            if (e.target.closest(this.constructor.editorFocusableSelector)) return
+            e.preventDefault() // keep focus in the editor instead of blurring to the frame
+            const editor = floater.querySelector('[autofocus]')
+                || floater.querySelector(this.constructor.editorFocusableSelector)
+            editor?.focus?.({ preventScroll: true })
+        })
+
         // Event-driven sugar over the session API: an editor may dispatch a bubbling
         // `commit` CustomEvent when its (possibly async) work is done.
         floater.addEventListener('commit', e => {
@@ -465,7 +487,7 @@ export default class Spreadsheet extends DataGrid {
         // focusable control.
         requestAnimationFrame(() => {
             const editor = floater.querySelector('[autofocus]')
-                || floater.querySelector('input, textarea, select, button, [contenteditable=""], [contenteditable=true], [tabindex], komp-content-area, komp-select')
+                || floater.querySelector(this.constructor.editorFocusableSelector)
             // preventScroll: the editor sits over the (already-visible) cell; focusing without
             // it can scroll the grid to the editor's pre-positioned origin (the utilities layer).
             editor?.focus?.({ preventScroll: true })
@@ -830,7 +852,7 @@ export default class Spreadsheet extends DataGrid {
         .${this.tagName}-input {
             z-index: 4;
         }
-        .${this.tagName}-input > label {
+        .${this.tagName}-input > .${this.tagName}-input-frame {
             display: flex;
             min-width: var(--cell-width, auto);
             min-height: var(--cell-height, auto);
@@ -838,16 +860,16 @@ export default class Spreadsheet extends DataGrid {
             outline: 2px solid var(--select-color);
             outline-offset: -1px;
             box-shadow: 0 0 0 3px oklch(var(--select-oklch) / 0.35);
-            
+
             display: flex;
             flex-direction: column;
             justify-content: space-between;
         }
-        .${this.tagName}-input > label > input,
-        .${this.tagName}-input > label > textarea,
-        .${this.tagName}-input > label > select,
-        .${this.tagName}-input > label > komp-content-area,
-        .${this.tagName}-input > label > komp-select > button {
+        .${this.tagName}-input > .${this.tagName}-input-frame > input,
+        .${this.tagName}-input > .${this.tagName}-input-frame > textarea,
+        .${this.tagName}-input > .${this.tagName}-input-frame > select,
+        .${this.tagName}-input > .${this.tagName}-input-frame > komp-content-area,
+        .${this.tagName}-input > .${this.tagName}-input-frame > komp-select > button {
             font: inherit;
             border: none;
             outline: none;
@@ -858,7 +880,7 @@ export default class Spreadsheet extends DataGrid {
             padding: 0.4em 0.6em;
             border-radius: unset;
         }
-        .${this.tagName}-input > label > input {
+        .${this.tagName}-input > .${this.tagName}-input-frame > input {
             width: 1px; // make so doesn't initially overflow column
         }
 


### PR DESCRIPTION
## Problem

When a Spreadsheet cell is edited, the built input is mounted in a `Floater` and wrapped in a `<label>` — "to catch stray clicks and direct focus" into the editor. That works for a single control, but a `<label>` always forwards a click to its **first** labelable control. So when an editor exposes multiple inputs/buttons, a stray click anywhere in the box's padding/gutter activates the first button instead of doing nothing — the cell can't control which control a stray click hits.

## Fix

- Wrap the editor in a plain `<div>` frame (`komp-spreadsheet-input-frame`) instead of a `<label>`.
- Redirect stray clicks with a `mousedown` handler on the floater:
  - clicks on a real control (`input`/`textarea`/`select`/`button`/`komp-content-area`/`komp-select`/contenteditable/tabindex) fall through to native handling;
  - clicks on the frame itself `preventDefault()` (so focus stays in the editor rather than blurring) and focus the intended control — the `[autofocus]` element, else the first focusable — **without activating anything**.
- Extract the focusable-control selector into a shared `static editorFocusableSelector` (reused by the initial-focus `requestAnimationFrame` and the new handler).
- Update the editor CSS selectors from `> label` to `> .komp-spreadsheet-input-frame`.

This preserves the original single-control behavior (stray clicks keep focus in the editor) while fixing the multi-control case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)