### PR TITLE
Fix Dropdown autofocus scrolling ancestor containers

### DIFF
--- a/lib/komps/dropdown.js
+++ b/lib/komps/dropdown.js
@@ -68,7 +68,10 @@ export default class Dropdown extends Floater {
         // Set initial focus to autofocus element or first focusable
         const initialFocus = this.querySelector('[autofocus]') || this.querySelector(Dropdown.FOCUSABLE_SELECTOR)
         if (initialFocus && !this.contains(document.activeElement)) {
-            initialFocus.focus()
+            // preventScroll: on connect the dropdown hasn't been positioned by
+            // floating-ui yet, so a scrolling focus would reveal its unpositioned
+            // origin — scrolling ancestors (e.g. a spreadsheet grid) to the wrong place.
+            initialFocus.focus({ preventScroll: true })
         }
     }
     


### PR DESCRIPTION
## Bug

When a Dropdown is shown inside a not-yet-positioned floater (e.g. the Spreadsheet select-column cell editor), `Dropdown.connected()` focuses the first option with a plain `focus()`. Floaters/dropdowns are appended to the DOM first and positioned by floating-ui asynchronously afterwards, so at focus time the dropdown still sits at its container's origin. The scrolling focus makes the browser scroll ancestor scroll containers to reveal that unpositioned element — in Spreadsheet, activating a select cell while scrolled right snapped `scrollLeft` back to 0 and left the editor floater stranded far from its cell.

## Fix

`focus({ preventScroll: true })`. Scrolling on this focus is never useful: floating-ui's flip/shift places the dropdown in view once positioning runs, and Spreadsheet already uses `preventScroll` on all its own editor focus calls for exactly this reason (see the comment in spreadsheet.js activateCell's requestAnimationFrame focus).

## Verified

Verified in the intel-rails app (Spreadsheet on the TIMs page, enum column): before the fix, activating the cell at scrollLeft=1178 reset scrollLeft to 0 and misplaced the floater by ~1100px; after, scroll position is preserved, the editor opens exactly over the cell, and option selection + commit work with no console errors.

Test suite: `npm test` — all 37 passing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)